### PR TITLE
feat(api): stub CRUD for checker template

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.0.0",
     "ace-builds": "^1.4.12",
+    "body-parser": "^1.19.0",
     "convict": "^6.0.0",
     "express": "^4.17.1",
     "framer-motion": "^3.1.4",

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -1,0 +1,15 @@
+import express, { Router } from 'express'
+import CheckerController from '../checker'
+
+export default (options: { checker: CheckerController }): Router => {
+  const { checker } = options
+  const api = express.Router()
+
+  // CRUD for checker template
+  api.post('/c', checker.post)
+  api.get('/c/:id', checker.get)
+  api.put('/c/:id', checker.put)
+  api.delete('/c/:id', checker.delete)
+
+  return api
+}

--- a/src/server/checker/CheckerController.ts
+++ b/src/server/checker/CheckerController.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express'
+export class CheckerController {
+  private repository: Record<string, Record<string, unknown>>
+
+  constructor() {
+    this.repository = {}
+  }
+
+  post: (_req: Request, _res: Response) => void = (req, res) => {
+    const checker = req.body
+    if (this.repository[checker.id]) {
+      res.status(400).send({ message: `${checker.id} already exists` })
+    } else {
+      this.repository[checker.id] = checker
+      res.send(checker)
+    }
+  }
+
+  get: (_req: Request, _res: Response) => void = (req, res) => {
+    const { id } = req.params
+    const checker = this.repository[id]
+    if (!checker) {
+      res.status(404).send({ message: 'Not Found' })
+    } else {
+      res.send(checker)
+    }
+  }
+
+  put: (_req: Request, _res: Response) => void = (req, res) => {
+    const { id } = req.params
+    if (!this.repository[id]) {
+      res.status(404).send({ message: 'Not Found' })
+    } else {
+      const checker = req.body
+      this.repository[id] = checker
+      res.send(checker)
+    }
+  }
+
+  delete: (_req: Request, _res: Response) => void = (req, res) => {
+    const { id } = req.params
+    const deleted = this.repository[id]
+    if (!deleted) {
+      res.status(404).send({ message: 'Not Found' })
+    } else {
+      delete this.repository[id]
+      res.send(deleted)
+    }
+  }
+}
+export default CheckerController

--- a/src/server/checker/index.ts
+++ b/src/server/checker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CheckerController'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,13 @@
-import express from 'express'
 import path from 'path'
 
+import express from 'express'
+import bodyParser from 'body-parser'
+
 import config from './config'
+import api from './api'
+import CheckerController from './checker'
+
+const checker = new CheckerController()
 
 const app = express()
 const port = config.get('port')
@@ -18,6 +24,7 @@ app.get('/debug', (_req, res) =>
   res.sendFile(path.resolve(__dirname + '/../../build/client/index.html'))
 )
 
-app.get('/api/hello', (_req, res) => res.send('Hello World'))
+const apiMiddleware = [bodyParser.json()]
+app.use('/api/v1', apiMiddleware, api({ checker }))
 
 app.listen(port, () => console.log(`Listening on port ${port}`))


### PR DESCRIPTION

## Problem

As a pro-active effort to provide some backend facilities to the dev team,
Refactor api into its own module, then inject a controller
that wraps around a stubbed checker repository

## Solution

- Create a module that acts as a factory for the Express router
  that embodies the API, taking in an options object for dependencies
- Mount the API at `/api/v1`
- Create a CheckerController to act as the Express controller for
  `/c` endpoints.
  - Let this wrap around an object that just keys strings to
    the checker templates
