### PR TITLE
style: rename evaluation functions

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -4,7 +4,7 @@ import { useForm, FormProvider } from 'react-hook-form'
 
 import { Checkbox, Radio, Numeric, DateField } from './fields'
 import * as checker from './../../types/checker'
-import { evaluateOperation } from './../core/evaluator'
+import { variableReducer } from './../core/evaluator'
 
 interface CheckerProps {
   config: checker.Checker
@@ -29,10 +29,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
   }
 
   const onSubmit = (inputVariables: Record<string, string | number>) => {
-    const computedVariables = operations.reduce(
-      evaluateOperation,
-      inputVariables
-    )
+    const computedVariables = operations.reduce(variableReducer, inputVariables)
     setVariables(computedVariables)
   }
 

--- a/src/client/core/__test__/evaluator.spec.ts
+++ b/src/client/core/__test__/evaluator.spec.ts
@@ -1,29 +1,29 @@
 import * as checker from '../../../types/checker'
-import { operation, evaluateOperation } from '../evaluator'
+import { evaluateOperation, variableReducer } from '../evaluator'
 
 describe('Operation', () => {
   describe('custom string equality', () => {
     it('should allow [number, number] comparisons', () => {
       const expr = 'a == b'
-      let output = operation(expr, { a: 1, b: 2 })
+      let output = evaluateOperation(expr, { a: 1, b: 2 })
       expect(output).toBe(false)
 
-      output = operation(expr, { a: 1, b: 1 })
+      output = evaluateOperation(expr, { a: 1, b: 1 })
       expect(output).toBe(true)
     })
 
     it('should allow [string, string] comparisons', () => {
       const expr = 'a == b'
-      let output = operation(expr, { a: 'hello', b: 'world' })
+      let output = evaluateOperation(expr, { a: 'hello', b: 'world' })
       expect(output).toBe(false)
 
-      output = operation(expr, { a: 'hello', b: 'hello' })
+      output = evaluateOperation(expr, { a: 'hello', b: 'hello' })
       expect(output).toBe(true)
     })
 
     it('should allow [string, number] comparisons', () => {
       const expr = 'a == b'
-      const output = operation(expr, { a: 1, b: 'world' })
+      const output = evaluateOperation(expr, { a: 1, b: 'world' })
       expect(output).toBe(false)
     })
   })
@@ -31,49 +31,49 @@ describe('Operation', () => {
   describe('ifelse', () => {
     it('should support [string, string] outputs', () => {
       const expr = 'ifelse(a > b, "hello", "world")'
-      const output = operation(expr, { a: 2, b: 1 })
+      const output = evaluateOperation(expr, { a: 2, b: 1 })
       expect(output).toBe('hello')
     })
 
     it('should support [number, number] outputs', () => {
       const expr = 'ifelse(a > b, 10, 20)'
-      const output = operation(expr, { a: 2, b: 1 })
+      const output = evaluateOperation(expr, { a: 2, b: 1 })
       expect(output).toBe(10)
     })
 
     it('should support [string, number] outputs', () => {
       const expr = 'ifelse(a > b, "hello", 20)'
-      const output = operation(expr, { a: 2, b: 1 })
+      const output = evaluateOperation(expr, { a: 2, b: 1 })
       expect(output).toBe('hello')
     })
 
     it('should support [number, string] outputs', () => {
       const expr = 'ifelse(a > b, 10, "hello")'
-      const output = operation(expr, { a: 2, b: 1 })
+      const output = evaluateOperation(expr, { a: 2, b: 1 })
       expect(output).toBe(10)
     })
 
     it('should not accept a string conditional', () => {
       const expr = 'ifelse("test", "hello", "world")'
-      expect(() => operation(expr, {})).toThrowError()
+      expect(() => evaluateOperation(expr, {})).toThrowError()
     })
 
     it('should not accept a number conditional', () => {
       const expr = 'ifelse(1, "hello", "world")'
-      expect(() => operation(expr, {})).toThrowError()
+      expect(() => evaluateOperation(expr, {})).toThrowError()
     })
   })
 })
 
-describe('evaluateOperation', () => {
-  it('should apply operation and accumulate variables', () => {
+describe('variableReducer', () => {
+  it('should apply evaluateOperation and accumulate variables', () => {
     const op: checker.Operation = {
       id: 'OUTPUT',
       type: 'ARITHMETIC',
       expression: 'a + b',
     }
     const inputs = { a: 1, b: 1 }
-    const vars = evaluateOperation(inputs, op)
+    const vars = variableReducer(inputs, op)
 
     expect(vars).toEqual({ ...inputs, OUTPUT: 2 })
   })

--- a/src/client/core/evaluator.ts
+++ b/src/client/core/evaluator.ts
@@ -32,18 +32,18 @@ const factories = {
 }
 export const math = create(factories, config)
 
-export function operation(
+export function evaluateOperation(
   expression: string,
   variables: Record<string, string | number>
 ): number {
   return math.evaluate!(expression, variables)
 }
 
-export const evaluateOperation = (
+export const variableReducer = (
   accVariables: Record<string, string | number>,
   op: checker.Operation
 ): Record<string, string | number> => {
   const { id, expression } = op
-  accVariables[id] = operation(expression, accVariables)
+  accVariables[id] = evaluateOperation(expression, accVariables)
   return accVariables
 }


### PR DESCRIPTION
This PR renames two evaluator functions described in https://github.com/opengovsg/checkfirst/pull/20#discussion_r557253157 and https://github.com/opengovsg/checkfirst/pull/20#discussion_r557250266 for clarity.