### PR TITLE
refactor(checker): cleanup

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -15,6 +15,7 @@ export default (options: {
 
   // CRUD for checker template
   api.post('/c', checker.post)
+  api.get('/c', checker.list)
   api.get('/c/:id', checker.get)
   api.put('/c/:id', checker.put)
   api.delete('/c/:id', checker.delete)

--- a/src/server/checker/CheckerController.ts
+++ b/src/server/checker/CheckerController.ts
@@ -21,6 +21,15 @@ export class CheckerController {
     }
   }
 
+  list: (req: Request, res: Response) => Promise<void> = async (_req, res) => {
+    try {
+      const checkers = await this.service.list()
+      res.json(checkers)
+    } catch (error) {
+      res.status(400).json({ message: error.message })
+    }
+  }
+
   get: (req: Request, res: Response) => Promise<void> = async (req, res) => {
     const { id } = req.params
     try {

--- a/src/server/checker/CheckerController.ts
+++ b/src/server/checker/CheckerController.ts
@@ -12,12 +12,12 @@ export class CheckerController {
     try {
       const created = await this.service.create(checker)
       if (!created) {
-        res.status(422).send({ message: `${checker.id} already exists` })
+        res.status(422).json({ message: `${checker.id} already exists` })
       } else {
-        res.send(checker)
+        res.json(checker)
       }
     } catch (error) {
-      res.status(400).send({ message: error.message })
+      res.status(400).json({ message: error.message })
     }
   }
 
@@ -26,12 +26,12 @@ export class CheckerController {
     try {
       const checker = await this.service.retrieve(id)
       if (!checker) {
-        res.status(404).send({ message: 'Not Found' })
+        res.status(404).json({ message: 'Not Found' })
       } else {
-        res.send(checker)
+        res.json(checker)
       }
     } catch (error) {
-      res.status(400).send({ message: error.message })
+      res.status(400).json({ message: error.message })
     }
   }
 
@@ -41,12 +41,12 @@ export class CheckerController {
     try {
       const count = await this.service.update(id, checker)
       if (!count) {
-        res.status(404).send({ message: 'Not Found' })
+        res.status(404).json({ message: 'Not Found' })
       } else {
-        res.send(checker)
+        res.json(checker)
       }
     } catch (error) {
-      res.status(400).send({ message: error.message })
+      res.status(400).json({ message: error.message })
     }
   }
 
@@ -55,12 +55,12 @@ export class CheckerController {
     try {
       const count = await this.service.delete(id)
       if (!count) {
-        res.status(404).send({ message: 'Not Found' })
+        res.status(404).json({ message: 'Not Found' })
       } else {
-        res.send({ message: `${id} deleted` })
+        res.json({ message: `${id} deleted` })
       }
     } catch (error) {
-      res.status(400).send({ message: error.message })
+      res.status(400).json({ message: error.message })
     }
   }
 }

--- a/src/server/checker/CheckerService.ts
+++ b/src/server/checker/CheckerService.ts
@@ -1,5 +1,6 @@
 import { ModelOf } from '../models'
 import { Checker } from '../../types/checker'
+import { WhereAttributeHash } from 'sequelize/types'
 
 export class CheckerService {
   private CheckerModel: ModelOf<Checker>
@@ -13,6 +14,13 @@ export class CheckerService {
       defaults: checker,
     })
     return created
+  }
+
+  list: (findOptions?: {
+    where: WhereAttributeHash
+  }) => Promise<Checker[]> = async (findOptions) => {
+    const result = await this.CheckerModel.findAll(findOptions)
+    return result
   }
 
   retrieve: (id: string) => Promise<Checker | null> = async (id) => {

--- a/src/server/checker/CheckerService.ts
+++ b/src/server/checker/CheckerService.ts
@@ -15,10 +15,9 @@ export class CheckerService {
     return created
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  retrieve: (id: string) => Promise<object | undefined> = async (id) => {
+  retrieve: (id: string) => Promise<Checker | null> = async (id) => {
     const result = await this.CheckerModel.findByPk(id)
-    return result?.toJSON()
+    return result
   }
 
   update: (id: string, checker: Partial<Checker>) => Promise<number> = async (

--- a/src/server/models/Checker.ts
+++ b/src/server/models/Checker.ts
@@ -24,11 +24,11 @@ export const init = (sequelize: SequelizeInstance): ModelOf<Checker> =>
       type: Sequelize.JSON,
       allowNull: false,
     },
-    results: {
+    operations: {
       type: Sequelize.JSON,
       allowNull: false,
     },
-    transformations: {
+    displays: {
       type: Sequelize.JSON,
       allowNull: false,
     },


### PR DESCRIPTION
## Problem

The backend for the checker infra was implemented in a hurry, and in need of a cleanup

## Solution

- remove eslint suppression for `service.retrieve()` return type now that `ModelOf` type corrected
- replace `res.send()` calls with `res.json()` in the controller
- stubplement the listing of checkers in Sequelize for the user dashboard on login
- correct the sequelize model fields so that they line up with `types/checker` declared properties