### PR TITLE
feat(auth): implement /logout , /whoami

### DIFF
--- a/src/client/hooks/use-local-storage.ts
+++ b/src/client/hooks/use-local-storage.ts
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+import { useEffect, useState } from 'react'
+
+function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T) => void] {
+  // Get from local storage then
+  // parse stored json or return initialValue
+  const readValue = () => {
+    // Prevent build error "window is undefined" but keep keep working
+    if (typeof window === 'undefined') {
+      return initialValue
+    }
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.warn(`Error reading localStorage key “${key}”:`, error)
+      return initialValue
+    }
+  }
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(readValue)
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T) => {
+    // Prevent build error "window is undefined" but keep keep working
+    if (typeof window == 'undefined') {
+      console.warn(
+        `Tried setting localStorage key “${key}” even though environment is not a client`
+      )
+    }
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(storedValue) : value
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(newValue))
+      // Save state
+      setStoredValue(newValue)
+      // We dispatch a custom event so every useLocalStorage hook are notified
+      window.dispatchEvent(new Event('local-storage'))
+    } catch (error) {
+      console.warn(`Error setting localStorage key “${key}”:`, error)
+    }
+  }
+  useEffect(() => {
+    setStoredValue(readValue())
+  }, [])
+  useEffect(() => {
+    const handleStorageChange = () => {
+      setStoredValue(readValue())
+    }
+    // this only works for other documents, not the current one
+    window.addEventListener('storage', handleStorageChange)
+    // this is a custom event, triggered in writeValueToLocalStorage
+    window.addEventListener('local-storage', handleStorageChange)
+    return () => {
+      window.removeEventListener('storage', handleStorageChange)
+      window.removeEventListener('local-storage', handleStorageChange)
+    }
+  }, [])
+  return [storedValue, setValue]
+}
+
+export default useLocalStorage

--- a/src/client/pages/Landing.tsx
+++ b/src/client/pages/Landing.tsx
@@ -8,16 +8,25 @@ export const Landing: FC = () => {
   const history = useHistory()
   const auth = useAuth()
 
+  const logout = auth.logout
+  const projects = () => history.push('/projects')
   const login = () => history.push('/login')
 
   return (
     <Flex direction="column" height="100vh">
       <Flex direction="row-reverse" w="100%" px={8} py={4}>
         {auth.isAuthenticated ? (
-          <Button colorScheme="primary">Logout</Button>
+          <>
+            <Button onClick={logout} colorScheme="primary">
+              Logout
+            </Button>
+            <Button onClick={projects} colorScheme="primary" variant="link">
+              Go to Projects
+            </Button>
+          </>
         ) : (
           <Button onClick={login} colorScheme="primary">
-            Sign in
+            Login
           </Button>
         )}
       </Flex>

--- a/src/client/services/AuthService.ts
+++ b/src/client/services/AuthService.ts
@@ -19,7 +19,12 @@ const verifyOtp = async ({
   })
 }
 
+const logout = async (): Promise<void> => {
+  await ApiClient.post<{ message: string }>('/auth/logout')
+}
+
 export const AuthService = {
   getOtp,
   verifyOtp,
+  logout,
 }

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -12,6 +12,8 @@ export default (options: {
   // Authentication and implicit account creation
   api.post('/auth', auth.sendOTP)
   api.post('/auth/verify', auth.verifyOTP)
+  api.get('/auth/whoami', auth.whoami)
+  api.post('/auth/logout', auth.logout)
 
   // CRUD for checker template
   api.post('/c', checker.post)

--- a/src/server/auth/AuthController.ts
+++ b/src/server/auth/AuthController.ts
@@ -42,4 +42,12 @@ export class AuthController {
       res.status(400).json({ message: error.message })
     }
   }
+
+  whoami: (req: Request, res: Response) => Promise<void> = async (req, res) => {
+    res.json(req.session.user || null)
+  }
+
+  logout: (req: Request, res: Response) => Promise<void> = async (req, res) => {
+    req.session.destroy(() => res.json({ message: 'Logged out' }))
+  }
 }

--- a/src/types/server/express-session.d.ts
+++ b/src/types/server/express-session.d.ts
@@ -1,0 +1,7 @@
+import User from '../user'
+
+declare module 'express-session' {
+  interface SessionData {
+    user: User
+  }
+}


### PR DESCRIPTION
## Problem

The frontend needs to logout and figure out if it has been authenticated 

## Solution
- implement `/whoami` and `/logout`, which do as their names imply
- use declaration merging to add a user property to `req.session`
- switch `isAuthenticated` from a state hook to a local storage hook
  derived from [1]
- implement `AuthService.logout()`, `AuthContext.logout()`
- hook Logout button to `AuthContext.logout()`, add link to Projects

## References
[1] - https://usehooks-typescript.com/react-hook/use-local-storage

## Acknowledgements
The author thanks @karrui for the hint on using local storage within
a React hook