### PR TITLE
feat(projects): implement navbar

### DIFF
--- a/src/client/components/LogoutButton.tsx
+++ b/src/client/components/LogoutButton.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from 'react'
+import { BiLogOutCircle } from 'react-icons/bi'
+import { Button } from '@chakra-ui/react'
+import { useHistory } from 'react-router-dom'
+
+import { useAuth } from '../contexts'
+
+export const LogoutButton: FC = () => {
+  const auth = useAuth()
+  const history = useHistory()
+
+  const logout = async () => {
+    await auth.logout()
+    history.push('/')
+  }
+
+  return (
+    <Button onClick={logout} variant="ghost" rightIcon={<BiLogOutCircle />}>
+      Sign Out
+    </Button>
+  )
+}

--- a/src/client/components/PrivateRoute.tsx
+++ b/src/client/components/PrivateRoute.tsx
@@ -3,9 +3,9 @@ import { Route, Redirect, RouteProps } from 'react-router-dom'
 import { useAuth } from '../contexts'
 
 export const PrivateRoute: FC<RouteProps> = ({ children, ...rest }) => {
-  const { isAuthenticated } = useAuth()
+  const { user } = useAuth()
   const renderRoute = ({ location }: RouteProps) =>
-    isAuthenticated ? (
+    user ? (
       children
     ) : (
       <Redirect to={{ pathname: '/login', state: { from: location } }} />

--- a/src/client/components/builder/Navbar.tsx
+++ b/src/client/components/builder/Navbar.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react'
-import { BiArrowBack, BiLogOutCircle } from 'react-icons/bi'
+import { BiArrowBack } from 'react-icons/bi'
 import { IconButton, Button, Flex, HStack } from '@chakra-ui/react'
+
+import { LogoutButton } from '../LogoutButton'
 
 export const Navbar: FC = () => {
   return (
@@ -39,9 +41,7 @@ export const Navbar: FC = () => {
       </HStack>
       <HStack>
         <Button colorScheme="primary">Save</Button>
-        <Button variant="ghost" rightIcon={<BiLogOutCircle />}>
-          Sign Out
-        </Button>
+        <LogoutButton />
       </HStack>
     </Flex>
   )

--- a/src/client/components/projects/Navbar.tsx
+++ b/src/client/components/projects/Navbar.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react'
+import { Flex, HStack, Text, Link } from '@chakra-ui/react'
+
+import { useAuth } from '../../contexts'
+import { LogoutButton } from '../LogoutButton'
+
+export const Navbar: FC = () => {
+  const auth = useAuth()
+  return (
+    <Flex
+      h="80px"
+      direction="row"
+      bgColor="white"
+      px={10}
+      alignItems="center"
+      position="fixed"
+      w="100%"
+    >
+      <HStack>
+        <Text>CheckFirst</Text>
+      </HStack>
+      <HStack h="100%" flex={1} justifyContent="center" />
+      <HStack>
+        <Link href="https://guide.checkfirst.gov.sg" mr={6} isExternal>
+          Guide
+        </Link>
+        <Text>{auth.user?.email || 'Not signed in'}</Text>
+        <LogoutButton />
+      </HStack>
+    </Flex>
+  )
+}

--- a/src/client/components/projects/index.tsx
+++ b/src/client/components/projects/index.tsx
@@ -1,0 +1,1 @@
+export { Navbar } from './Navbar'

--- a/src/client/pages/Landing.tsx
+++ b/src/client/pages/Landing.tsx
@@ -16,7 +16,7 @@ export const Landing: FC = () => {
   return (
     <Flex direction="column" height="100vh">
       <Flex direction="row-reverse" w="100%" px={8} py={4}>
-        {auth.isAuthenticated ? (
+        {auth.user ? (
           <HStack>
             <Button onClick={projects} variant="ghost">
               Go to Projects

--- a/src/client/pages/Projects.tsx
+++ b/src/client/pages/Projects.tsx
@@ -1,6 +1,17 @@
 import React, { FC } from 'react'
-import { Flex } from '@chakra-ui/react'
+import { Container, Flex, VStack } from '@chakra-ui/react'
+
+import { Navbar } from '../components/projects'
 
 export const Projects: FC = () => {
-  return <Flex>This is the project page</Flex>
+  return (
+    <Flex direction="column" minH="100vh" bgColor="#F4F6F9">
+      <Navbar />
+      <Container maxW="756px" pt="80px" px={0}>
+        <VStack align="stretch" py={10} position="relative">
+          <Flex layerStyle="builderField">Dummy field</Flex>
+        </VStack>
+      </Container>
+    </Flex>
+  )
 }


### PR DESCRIPTION
## Context
![image](https://user-images.githubusercontent.com/10572368/105125299-07502380-5b17-11eb-854d-3743e2073622.png)

The projects page has to be fleshed out to allow users to create and manage checkers. 

This PR seeks to put in place a navigation bar. It also changes AuthContext to expose
more information, information that the user will expect to see on successful login.

## Details

- Copy the navbar from builder, and restructure it to fit wireframe
- Create a common LogoutButton and use in projects and builder navbars,
  complete with functionality to logout and redirect to home page
- Deliberately avoid the tab interface proposed for the dashboard,
  as we are unlikely to have settings, leaving just one panel