### PR TITLE
feat: add reducer to Builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7808,6 +7808,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "immutability-helper": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+      "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.1",
     "framer-motion": "^3.2.1",
+    "immutability-helper": "^3.1.1",
     "lodash": "^4.17.20",
     "mathjs": "^8.1.1",
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://checkfirst.gov.sg",
   "scripts": {
     "lint": "eslint .",
-    "lint-fix": "eslint --fix .",
+    "lint-fix": "eslint --fix ./src",
     "test": "jest",
     "build": "tsc && webpack --mode production",
     "dev": "concurrently \"npm run dev-server\" \"npm run dev-client\"",

--- a/src/client/components/builder/CheckboxField.tsx
+++ b/src/client/components/builder/CheckboxField.tsx
@@ -24,7 +24,6 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
 
   const updateQuestion = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
-    console.log('update question', value)
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
@@ -37,7 +36,6 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
 
   const deleteOption = (option: checker.FieldOption, i: number) => {
     field.options.splice(i, 1)
-    console.log(field.options, 'delete option field')
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
@@ -55,7 +53,6 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   ) => {
     const updatedOption = { ...option, ...update }
     field.options.splice(i, 1, updatedOption)
-    console.log(field.options, 'my option updated')
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {

--- a/src/client/components/builder/CheckboxField.tsx
+++ b/src/client/components/builder/CheckboxField.tsx
@@ -55,6 +55,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   ) => {
     const updatedOption = { ...option, ...update }
     field.options.splice(i, 1, updatedOption)
+    console.log(field.options, 'my option updated')
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
@@ -71,7 +72,6 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
     const newValue = field.options[field.options.length - 1].value + 1
     const newOption = { label: newOptionLabel, value: newValue }
     field.options.push(newOption)
-    console.log(field.options, 'add option field after push')
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
@@ -88,7 +88,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
         <Checkbox isChecked={false} />
         <Input
           type="text"
-          value={option.value}
+          value={option.label}
           onChange={(e) => {
             updateOption(option, { label: e.target.value }, i)
           }}

--- a/src/client/components/builder/CheckboxField.tsx
+++ b/src/client/components/builder/CheckboxField.tsx
@@ -14,31 +14,72 @@ import {
 
 import * as checker from '../../../types/checker'
 import { createQuestionField, QuestionFieldComponent } from './QuestionField'
+import { useCheckerContext } from '../../contexts'
 
-const InputComponent: QuestionFieldComponent = ({ field }) => {
+import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+
+const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { description } = field
-
-  // TODO: Complete following functions by calling appropriate dispatch
+  const { dispatch } = useCheckerContext()
 
   const updateQuestion = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
     console.log('update question', value)
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, description: value },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
   }
 
-  const deleteOption = (option: checker.FieldOption) => {
-    console.log('delete option', option)
+  const deleteOption = (option: checker.FieldOption, i: number) => {
+    field.options.splice(i, 1)
+    console.log(field.options, 'delete option field')
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, options: field.options },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
   }
 
   const updateOption = (
     option: checker.FieldOption,
-    update: Partial<checker.FieldOption>
+    update: Partial<checker.FieldOption>,
+    i: number
   ) => {
-    const newOption = { ...option, ...update }
-    console.log('update option', newOption)
+    const updatedOption = { ...option, ...update }
+    field.options.splice(i, 1, updatedOption)
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, options: field.options },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
   }
 
   const addOption = () => {
-    console.log('add new option')
+    const newOptionLabel = `Option ${field.options.length + 1}`
+    // newValue is an increment of the last option's value to ensure that values are unique
+    const newValue = field.options[field.options.length - 1].value + 1
+    const newOption = { label: newOptionLabel, value: newValue }
+    field.options.push(newOption)
+    console.log(field.options, 'add option field after push')
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, options: field.options },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
   }
 
   const renderOption = (option: checker.FieldOption, i: number) => {
@@ -49,14 +90,14 @@ const InputComponent: QuestionFieldComponent = ({ field }) => {
           type="text"
           value={option.value}
           onChange={(e) => {
-            updateOption(option, { value: e.target.value })
+            updateOption(option, { label: e.target.value }, i)
           }}
         />
         <IconButton
           aria-label="Delete option"
           fontSize="20px"
           icon={<BiX />}
-          onClick={() => deleteOption(option)}
+          onClick={() => deleteOption(option, i)}
         />
       </HStack>
     )
@@ -100,9 +141,9 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
       </HStack>
       <CheckboxGroup>
         <VStack alignItems="left" spacing={2}>
-          {options.map(({ value }, i) => (
+          {options.map(({ value, label }, i) => (
             <Checkbox key={i} value={value} isChecked={false}>
-              {value}
+              {label}
             </Checkbox>
           ))}
         </VStack>

--- a/src/client/components/builder/NumericField.tsx
+++ b/src/client/components/builder/NumericField.tsx
@@ -3,14 +3,24 @@ import { BiHash } from 'react-icons/bi'
 import { useStyles, Box, HStack, VStack, Text, Input } from '@chakra-ui/react'
 
 import { createQuestionField, QuestionFieldComponent } from './QuestionField'
+import { useCheckerContext } from '../../contexts'
 
-const InputComponent: QuestionFieldComponent = ({ field }) => {
+import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+
+const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { description } = field
   const styles = useStyles()
+  const { dispatch } = useCheckerContext()
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
-    // TODO: Dispatch value to save new question
-    console.log(`dispatch value ${value}`)
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, description: value },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
   }
 
   return (

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -18,56 +18,50 @@ import {
   TitleField,
 } from '../builder'
 
-const metadata = { title: 'Title', description: 'This is an example checker.' }
-const fields: checker.Field[] = [
-  {
-    id: 'A',
-    type: 'NUMERIC',
-    description: 'Question 1',
-    help: '',
-    options: [],
-  },
-  {
-    id: 'B',
-    type: 'NUMERIC',
-    description: 'Question 2',
-    help: '',
-    options: [],
-  },
-  {
-    id: 'C',
-    type: 'RADIO',
-    description: 'Question 3',
-    help: '',
-    options: [{ value: 'Option 1' }, { value: 'Option 2' }],
-  },
-  {
-    id: 'D',
-    type: 'RADIO',
-    description: 'Question 4',
-    help: '',
-    options: [{ value: 'Option 1' }, { value: 'Option 2' }],
-  },
-  {
-    id: 'E',
-    type: 'CHECKBOX',
-    description: 'Question 5',
-    help: '',
-    options: [{ value: 'Option 1' }, { value: 'Option 2' }],
-  },
-  {
-    id: 'F',
-    type: 'CHECKBOX',
-    description: 'Question 6',
-    help: '',
-    options: [{ value: 'Option 1' }, { value: 'Option 2' }],
-  },
-]
+import { useCheckerContext } from '../../contexts'
+
+import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+
+const TITLE_FIELD_INDEX = -1
+
+const defaultNumericField: checker.Field = {
+  id: 'N',
+  type: 'NUMERIC',
+  description: 'Insert question description',
+  help: '',
+  options: [],
+}
+
+const defaultRadioField: checker.Field = {
+  id: 'R',
+  type: 'RADIO',
+  description: 'Insert question description',
+  help: '',
+  options: [
+    { label: 'Option 1', value: 0 },
+    { label: 'Option 2', value: 1 },
+  ],
+}
+
+const defaultCheckboxField: checker.Field = {
+  id: 'C',
+  type: 'CHECKBOX',
+  description: 'Insert question description',
+  help: '',
+  options: [
+    { label: 'Option 1', value: 0 },
+    { label: 'Option 2', value: 1 },
+  ],
+}
+
 export const TITLE_FIELD_ID = 'TITLE'
 
 export const QuestionsTab: FC = () => {
-  const [activeId, setActiveId] = useState<string>(fields[0].id)
+  const [activeIndex, setActiveIndex] = useState<number>(-1)
   const [offsetTop, setOffsetTop] = useState<number>(16)
+  const { config, dispatch } = useCheckerContext()
+
+  const { title, description, fields } = config
 
   const toolbarOptions = [
     {
@@ -77,50 +71,103 @@ export const QuestionsTab: FC = () => {
         {
           label: 'Numeric field',
           icon: <BiHash />,
-          onClick: () => console.log('Add numeric field'),
+          onClick: () => {
+            dispatch({
+              type: BuilderActionEnum.Add,
+              payload: {
+                element: defaultNumericField,
+                configArrName: ConfigArrayEnum.Fields,
+                newIndex: activeIndex + 1,
+              },
+            })
+            setActiveIndex(activeIndex + 1)
+          },
         },
         {
           label: 'Radio',
           icon: <BiRadioCircleMarked />,
-          onClick: () => console.log('Add radio field'),
+          onClick: () => {
+            dispatch({
+              type: BuilderActionEnum.Add,
+              payload: {
+                element: defaultRadioField,
+                configArrName: ConfigArrayEnum.Fields,
+                newIndex: activeIndex + 1,
+              },
+            })
+            setActiveIndex(activeIndex + 1)
+          },
         },
         {
           label: 'Checkbox',
           icon: <BiCheckboxChecked />,
-          onClick: () => console.log('Add checkbox field'),
+          onClick: () => {
+            dispatch({
+              type: BuilderActionEnum.Add,
+              payload: {
+                element: defaultCheckboxField,
+                configArrName: ConfigArrayEnum.Fields,
+                newIndex: activeIndex + 1,
+              },
+            })
+            setActiveIndex(activeIndex + 1)
+          },
         },
       ],
     },
     {
       icon: <BiUpArrowAlt />,
       label: 'Move up',
-      onClick: () => console.log('move up'),
-      disabled: activeId === TITLE_FIELD_ID || activeId === fields[0].id,
+      onClick: () => {
+        dispatch({
+          type: BuilderActionEnum.Reorder,
+          payload: {
+            currIndex: activeIndex,
+            newIndex: activeIndex - 1,
+            configArrName: ConfigArrayEnum.Fields,
+          },
+        })
+        setActiveIndex(activeIndex - 1)
+      },
+      disabled: activeIndex === TITLE_FIELD_INDEX || activeIndex === 0,
     },
     {
       icon: <BiDownArrowAlt />,
       label: 'Move down',
-      onClick: () => console.log('move down'),
-      disabled: activeId === fields[fields.length - 1].id,
+      onClick: () => {
+        dispatch({
+          type: BuilderActionEnum.Reorder,
+          payload: {
+            currIndex: activeIndex,
+            newIndex: activeIndex + 1,
+            configArrName: ConfigArrayEnum.Fields,
+          },
+        })
+        setActiveIndex(activeIndex + 1)
+      },
+      disabled:
+        activeIndex === TITLE_FIELD_INDEX || activeIndex === fields.length - 1,
     },
   ]
 
-  const onSelect = ({ id }: { id: string }) => {
-    setActiveId(id)
+  const onSelect = ({ index }: { index: number }) => {
+    setActiveIndex(index)
   }
 
   const onActive = ({ top }: { top: number }) => {
     setOffsetTop(top)
   }
 
-  const renderField = (field: checker.Field) => {
+  const renderField = (field: checker.Field, index: number) => {
     const commonProps = {
-      key: field.id,
+      key: field.id + index,
       id: field.id,
-      active: activeId === field.id,
+      active: activeIndex === index,
       data: field,
+      index,
       onActive,
       onSelect,
+      setActiveIndex,
     }
 
     switch (field.type) {
@@ -136,15 +183,15 @@ export const QuestionsTab: FC = () => {
   return (
     <Container maxW="756px" px={0}>
       <VStack align="stretch" position="relative" spacing={4}>
-        {activeId && (
-          <FloatingToolbar offsetTop={offsetTop} options={toolbarOptions} />
-        )}
+        <FloatingToolbar offsetTop={offsetTop} options={toolbarOptions} />
         <TitleField
           id={TITLE_FIELD_ID}
-          active={activeId === TITLE_FIELD_ID}
-          data={metadata}
+          active={activeIndex === TITLE_FIELD_INDEX}
+          data={{ title, description }}
           onSelect={onSelect}
           onActive={onActive}
+          index={TITLE_FIELD_INDEX}
+          setActiveIndex={setActiveIndex}
         />
         {fields.map(renderField)}
       </VStack>

--- a/src/client/components/builder/RadioField.tsx
+++ b/src/client/components/builder/RadioField.tsx
@@ -35,7 +35,6 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
 
   const deleteOption = (option: checker.FieldOption, i: number) => {
     field.options.splice(i, 1)
-    console.log(field.options, 'delete option field')
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
@@ -69,7 +68,6 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
     const newValue = field.options[field.options.length - 1].value + 1
     const newOption = { label: newOptionLabel, value: newValue }
     field.options.push(newOption)
-    console.log(field.options, 'add option field after push')
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
@@ -86,7 +84,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
         <Radio isChecked={false} />
         <Input
           type="text"
-          value={option.value}
+          value={option.label}
           onChange={(e) => {
             updateOption(option, { label: e.target.value }, i)
           }}

--- a/src/client/components/builder/TitleField.tsx
+++ b/src/client/components/builder/TitleField.tsx
@@ -3,14 +3,27 @@ import { BiText } from 'react-icons/bi'
 import { Box, HStack, VStack, Text, Input, Heading } from '@chakra-ui/react'
 
 import { createQuestionField, TitleFieldComponent } from './QuestionField'
+import { useCheckerContext } from '../../contexts'
+import { BuilderActionEnum } from '../../../util/enums'
+
+const enum SettingsName {
+  description = 'description',
+  title = 'title',
+}
 
 const InputComponent: TitleFieldComponent = ({ title, description }) => {
+  const { dispatch } = useCheckerContext()
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    const update = { [name]: value }
-
+    const update = { settingsName: name as SettingsName, value }
     // TODO: Dispatch value to save new title and description
-    console.log(`dispatch value`, update)
+
+    console.log(update, 'my title field changed')
+    dispatch({
+      type: BuilderActionEnum.UpdateSettings,
+      payload: update,
+    })
   }
 
   return (
@@ -21,14 +34,14 @@ const InputComponent: TitleFieldComponent = ({ title, description }) => {
       <VStack align="stretch" w="100%">
         <Input
           type="text"
-          name="title"
+          name={SettingsName.title}
           placeholder="Title"
           onChange={handleChange}
           value={title}
         />
         <Input
           type="text"
-          name="description"
+          name={SettingsName.description}
           placeholder="Description"
           onChange={handleChange}
           value={description}

--- a/src/client/components/fields/CheckboxField.tsx
+++ b/src/client/components/fields/CheckboxField.tsx
@@ -32,11 +32,16 @@ export const CheckboxField: FC<CheckboxProps> = ({
           {help && <FormHelperText mb={4}>{help}</FormHelperText>}
           <CheckboxGroup onChange={onChange} value={value}>
             <Stack direction="column">
-              {options.map(({ value, label }: { value: number, label: string }, i: number) => (
-                <CheckboxInput key={i} ref={ref} name={id} value={value}>
-                  {label}
-                </CheckboxInput>
-              ))}
+              {options.map(
+                (
+                  { value, label }: { value: number; label: string },
+                  i: number
+                ) => (
+                  <CheckboxInput key={i} ref={ref} name={id} value={value}>
+                    {label}
+                  </CheckboxInput>
+                )
+              )}
             </Stack>
           </CheckboxGroup>
         </FormControl>

--- a/src/client/components/fields/CheckboxField.tsx
+++ b/src/client/components/fields/CheckboxField.tsx
@@ -32,9 +32,9 @@ export const CheckboxField: FC<CheckboxProps> = ({
           {help && <FormHelperText mb={4}>{help}</FormHelperText>}
           <CheckboxGroup onChange={onChange} value={value}>
             <Stack direction="column">
-              {options.map(({ value }: { value: string }, i: number) => (
+              {options.map(({ value, label }: { value: number, label: string }, i: number) => (
                 <CheckboxInput key={i} ref={ref} name={id} value={value}>
-                  {value}
+                  {label}
                 </CheckboxInput>
               ))}
             </Stack>

--- a/src/client/components/fields/RadioField.tsx
+++ b/src/client/components/fields/RadioField.tsx
@@ -35,11 +35,16 @@ export const RadioField: FC<RadioProps> = ({
           {help && <FormHelperText mb={4}>{help}</FormHelperText>}
           <RadioGroup name={id} value={value} onChange={onChange}>
             <Stack direction="column">
-              {options.map(({ value, label }: { value: number, label: string }, i: number) => (
-                <RadioInput key={i} ref={ref} name={id} value={value}>
-                  {label}
-                </RadioInput>
-              ))}
+              {options.map(
+                (
+                  { value, label }: { value: number; label: string },
+                  i: number
+                ) => (
+                  <RadioInput key={i} ref={ref} name={id} value={value}>
+                    {label}
+                  </RadioInput>
+                )
+              )}
             </Stack>
           </RadioGroup>
           <FormErrorMessage>Field is required</FormErrorMessage>

--- a/src/client/components/fields/RadioField.tsx
+++ b/src/client/components/fields/RadioField.tsx
@@ -35,9 +35,9 @@ export const RadioField: FC<RadioProps> = ({
           {help && <FormHelperText mb={4}>{help}</FormHelperText>}
           <RadioGroup name={id} value={value} onChange={onChange}>
             <Stack direction="column">
-              {options.map(({ value }: { value: string }, i: number) => (
+              {options.map(({ value, label }: { value: number, label: string }, i: number) => (
                 <RadioInput key={i} ref={ref} name={id} value={value}>
-                  {value}
+                  {label}
                 </RadioInput>
               ))}
             </Stack>

--- a/src/client/contexts/CheckerContext.tsx
+++ b/src/client/contexts/CheckerContext.tsx
@@ -7,6 +7,7 @@ import {
   BuilderUpdatePayload,
   BuilderRemovePayload,
   BuilderReorderPayload,
+  BuilderUpdateSettingsPayload,
 } from '../../types/builder'
 
 import { BuilderActionEnum } from '../../util/enums'
@@ -25,10 +26,10 @@ export const reducer = (state: Checker, action: BuilderAction): Checker => {
 
   switch (type) {
     case BuilderActionEnum.Add: {
-      const { configArrName, element } = payload as BuilderAddPayload
+      const { configArrName, element, newIndex } = payload as BuilderAddPayload
       newState = update(state, {
         [configArrName]: {
-          $push: [element],
+          $splice: [[newIndex, 0, element]],
         },
       })
       return newState
@@ -78,13 +79,25 @@ export const reducer = (state: Checker, action: BuilderAction): Checker => {
       return newState
     }
 
+    case BuilderActionEnum.UpdateSettings: {
+      const { settingsName, value } = payload as BuilderUpdateSettingsPayload
+
+      newState = update(state, {
+        [settingsName]: {
+          $set: value,
+        },
+      })
+
+      return newState
+    }
+
     default:
       return state
   }
 }
 
 interface CheckerContextProps {
-  config: Partial<Checker>
+  config: Checker
   dispatch: React.Dispatch<BuilderAction>
   save: () => Promise<void>
 }

--- a/src/client/contexts/CheckerContext.tsx
+++ b/src/client/contexts/CheckerContext.tsx
@@ -103,7 +103,7 @@ interface CheckerContextProps {
 }
 
 const initialConfig = {
-  id: '1', // uuid() or existing id from DB
+  id: 'initial-checker', // uuid() or existing id from DB
   title: 'Checker Title',
   description: 'My description',
   fields: [],

--- a/src/client/contexts/__test__/CheckerContext.spec.ts
+++ b/src/client/contexts/__test__/CheckerContext.spec.ts
@@ -69,7 +69,7 @@ describe('Testing CheckerContext reducer add actions', () => {
   it('should return state with added field', () => {
     const action: BuilderAction = {
       type: BuilderActionEnum.Add,
-      payload: { element: newField, configArrName: ConfigArrayEnum.Fields },
+      payload: { element: newField, configArrName: ConfigArrayEnum.Fields, newIndex: 1 },
     }
     const state = initialChecker
     const expectedState = {
@@ -87,6 +87,7 @@ describe('Testing CheckerContext reducer add actions', () => {
       payload: {
         element: newOperation,
         configArrName: ConfigArrayEnum.Operations,
+        newIndex: 1
       },
     }
     const state = initialChecker
@@ -102,7 +103,7 @@ describe('Testing CheckerContext reducer add actions', () => {
   it('should return state with added display', () => {
     const action: BuilderAction = {
       type: BuilderActionEnum.Add,
-      payload: { element: newDisplay, configArrName: ConfigArrayEnum.Displays },
+      payload: { element: newDisplay, configArrName: ConfigArrayEnum.Displays, newIndex: 1 },
     }
     const state = initialChecker
     const expectedState = {
@@ -120,6 +121,7 @@ describe('Testing CheckerContext reducer add actions', () => {
       payload: {
         element: newConstant,
         configArrName: ConfigArrayEnum.Constants,
+        newIndex: 1
       },
     }
     const state = initialChecker
@@ -293,7 +295,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
   it('should return state with reordered field', () => {
     const addAction: BuilderAction = {
       type: BuilderActionEnum.Add,
-      payload: { element: newField, configArrName: ConfigArrayEnum.Fields },
+      payload: { element: newField, configArrName: ConfigArrayEnum.Fields, newIndex: 1 },
     }
     const reorderAction: BuilderAction = {
       type: BuilderActionEnum.Reorder,
@@ -320,6 +322,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
       payload: {
         element: newOperation,
         configArrName: ConfigArrayEnum.Operations,
+        newIndex: 1
       },
     }
     const reorderAction: BuilderAction = {
@@ -347,6 +350,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
       payload: {
         element: newDisplay,
         configArrName: ConfigArrayEnum.Displays,
+        newIndex: 1
       },
     }
     const reorderAction: BuilderAction = {
@@ -374,6 +378,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
       payload: {
         element: newConstant,
         configArrName: ConfigArrayEnum.Constants,
+        newIndex: 1
       },
     }
     const reorderAction: BuilderAction = {

--- a/src/client/contexts/__test__/CheckerContext.spec.ts
+++ b/src/client/contexts/__test__/CheckerContext.spec.ts
@@ -69,7 +69,11 @@ describe('Testing CheckerContext reducer add actions', () => {
   it('should return state with added field', () => {
     const action: BuilderAction = {
       type: BuilderActionEnum.Add,
-      payload: { element: newField, configArrName: ConfigArrayEnum.Fields, newIndex: 1 },
+      payload: {
+        element: newField,
+        configArrName: ConfigArrayEnum.Fields,
+        newIndex: 1,
+      },
     }
     const state = initialChecker
     const expectedState = {
@@ -87,7 +91,7 @@ describe('Testing CheckerContext reducer add actions', () => {
       payload: {
         element: newOperation,
         configArrName: ConfigArrayEnum.Operations,
-        newIndex: 1
+        newIndex: 1,
       },
     }
     const state = initialChecker
@@ -103,7 +107,11 @@ describe('Testing CheckerContext reducer add actions', () => {
   it('should return state with added display', () => {
     const action: BuilderAction = {
       type: BuilderActionEnum.Add,
-      payload: { element: newDisplay, configArrName: ConfigArrayEnum.Displays, newIndex: 1 },
+      payload: {
+        element: newDisplay,
+        configArrName: ConfigArrayEnum.Displays,
+        newIndex: 1,
+      },
     }
     const state = initialChecker
     const expectedState = {
@@ -121,7 +129,7 @@ describe('Testing CheckerContext reducer add actions', () => {
       payload: {
         element: newConstant,
         configArrName: ConfigArrayEnum.Constants,
-        newIndex: 1
+        newIndex: 1,
       },
     }
     const state = initialChecker
@@ -295,7 +303,11 @@ describe('Testing CheckerContext reducer reorder actions', () => {
   it('should return state with reordered field', () => {
     const addAction: BuilderAction = {
       type: BuilderActionEnum.Add,
-      payload: { element: newField, configArrName: ConfigArrayEnum.Fields, newIndex: 1 },
+      payload: {
+        element: newField,
+        configArrName: ConfigArrayEnum.Fields,
+        newIndex: 1,
+      },
     }
     const reorderAction: BuilderAction = {
       type: BuilderActionEnum.Reorder,
@@ -322,7 +334,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
       payload: {
         element: newOperation,
         configArrName: ConfigArrayEnum.Operations,
-        newIndex: 1
+        newIndex: 1,
       },
     }
     const reorderAction: BuilderAction = {
@@ -350,7 +362,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
       payload: {
         element: newDisplay,
         configArrName: ConfigArrayEnum.Displays,
-        newIndex: 1
+        newIndex: 1,
       },
     }
     const reorderAction: BuilderAction = {
@@ -378,7 +390,7 @@ describe('Testing CheckerContext reducer reorder actions', () => {
       payload: {
         element: newConstant,
         configArrName: ConfigArrayEnum.Constants,
-        newIndex: 1
+        newIndex: 1,
       },
     }
     const reorderAction: BuilderAction = {

--- a/src/client/contexts/__test__/CheckerContext.spec.ts
+++ b/src/client/contexts/__test__/CheckerContext.spec.ts
@@ -1,12 +1,397 @@
-import { reducer, FormActionType } from '../CheckerContext'
+import { reducer } from '../CheckerContext'
+import { BuilderAction } from '../../../types/builder'
+import {
+  Checker,
+  Field,
+  Operation,
+  Display,
+  Constant,
+  // ConfigArrayEnum
+} from '../../../types/checker'
 
-describe('CheckerContext reducer', () => {
-  // Placeholder test for reducer
-  it('should return state by default', () => {
-    const action = { type: FormActionType.Add }
-    const state = { title: 'Test' }
+import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+
+// Objects for the initial checker
+const initialField: Field = {
+  id: 'initial_field',
+  type: 'NUMERIC',
+  description: 'Initial field',
+  help: '',
+  options: [],
+}
+const initialOperation: Operation = {
+  id: 'initial_operation',
+  type: 'ARITHMETIC',
+  expression: '2 * 8',
+}
+const initialDisplay: Display = {
+  id: 'initial_display',
+  type: 'TEXT',
+  targets: ['initial_field'],
+}
+const initialConstant: Constant = {
+  id: 'initial_constant',
+  value: 'Initial constant string',
+}
+const initialChecker: Checker = {
+  id: 'Initial',
+  title: 'Checker test',
+  fields: [initialField],
+  operations: [initialOperation],
+  constants: [initialConstant],
+  displays: [initialDisplay],
+}
+
+// Objects to be used by the test cases
+const newField: Field = {
+  id: 'new_field',
+  type: 'NUMERIC',
+  description: 'a Field object to test actions on the Builder',
+  help: '',
+  options: [],
+}
+const newOperation: Operation = {
+  id: 'new_operation',
+  type: 'ARITHMETIC',
+  expression: '1 + 2',
+}
+const newDisplay: Display = {
+  id: 'new_display',
+  type: 'TEXT',
+  targets: ['initial_operation'],
+}
+const newConstant: Constant = {
+  id: 'new_constant',
+  value: 'New constant string',
+}
+
+describe('Testing CheckerContext reducer add actions', () => {
+  it('should return state with added field', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: { element: newField, configArrName: ConfigArrayEnum.Fields },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      fields: [initialField, newField],
+    }
 
     const updatedState = reducer(state, action)
-    expect(updatedState).toEqual(state)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with added operation', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: {
+        element: newOperation,
+        configArrName: ConfigArrayEnum.Operations,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      operations: [initialOperation, newOperation],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with added display', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: { element: newDisplay, configArrName: ConfigArrayEnum.Displays },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      displays: [initialDisplay, newDisplay],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with added constant', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: {
+        element: newConstant,
+        configArrName: ConfigArrayEnum.Constants,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      constants: [initialConstant, newConstant],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+})
+
+describe('Testing CheckerContext reducer remove actions', () => {
+  const initialElementIndex = 0
+  it('should return state with removed field', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Remove,
+      payload: {
+        currIndex: initialElementIndex,
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      fields: [],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with removed operation', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Remove,
+      payload: {
+        currIndex: initialElementIndex,
+        configArrName: ConfigArrayEnum.Operations,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      operations: [],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with removed display', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Remove,
+      payload: {
+        currIndex: initialElementIndex,
+        configArrName: ConfigArrayEnum.Displays,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      displays: [],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with removed constant', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Remove,
+      payload: {
+        currIndex: initialElementIndex,
+        configArrName: ConfigArrayEnum.Constants,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      constants: [],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+})
+
+describe('Testing CheckerContext reducer update actions', () => {
+  const initialElementIndex = 0
+  it('should return state with updated field', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Update,
+      payload: {
+        element: newField,
+        configArrName: ConfigArrayEnum.Fields,
+        currIndex: initialElementIndex,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      fields: [newField],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with updated operation', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Update,
+      payload: {
+        element: newOperation,
+        configArrName: ConfigArrayEnum.Operations,
+        currIndex: initialElementIndex,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      operations: [newOperation],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with updated display', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Update,
+      payload: {
+        element: newDisplay,
+        configArrName: ConfigArrayEnum.Displays,
+        currIndex: initialElementIndex,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      displays: [newDisplay],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with updated constant', () => {
+    const action: BuilderAction = {
+      type: BuilderActionEnum.Update,
+      payload: {
+        element: newConstant,
+        configArrName: ConfigArrayEnum.Constants,
+        currIndex: initialElementIndex,
+      },
+    }
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      constants: [newConstant],
+    }
+
+    const updatedState = reducer(state, action)
+    expect(updatedState).toEqual(expectedState)
+  })
+})
+
+describe('Testing CheckerContext reducer reorder actions', () => {
+  const initialElementIndex = 0
+  const finalElementIndex = 1
+  it('should return state with reordered field', () => {
+    const addAction: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: { element: newField, configArrName: ConfigArrayEnum.Fields },
+    }
+    const reorderAction: BuilderAction = {
+      type: BuilderActionEnum.Reorder,
+      payload: {
+        currIndex: initialElementIndex,
+        newIndex: finalElementIndex,
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    }
+    const actionsArray = [addAction, reorderAction]
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      fields: [newField, initialField],
+    }
+
+    const updatedState = actionsArray.reduce(reducer, state)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with reordered operation', () => {
+    const addAction: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: {
+        element: newOperation,
+        configArrName: ConfigArrayEnum.Operations,
+      },
+    }
+    const reorderAction: BuilderAction = {
+      type: BuilderActionEnum.Reorder,
+      payload: {
+        currIndex: initialElementIndex,
+        newIndex: finalElementIndex,
+        configArrName: ConfigArrayEnum.Operations,
+      },
+    }
+    const actionsArray = [addAction, reorderAction]
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      operations: [newOperation, initialOperation],
+    }
+
+    const updatedState = actionsArray.reduce(reducer, state)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with reordered display', () => {
+    const addAction: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: {
+        element: newDisplay,
+        configArrName: ConfigArrayEnum.Displays,
+      },
+    }
+    const reorderAction: BuilderAction = {
+      type: BuilderActionEnum.Reorder,
+      payload: {
+        currIndex: initialElementIndex,
+        newIndex: finalElementIndex,
+        configArrName: ConfigArrayEnum.Displays,
+      },
+    }
+    const actionsArray = [addAction, reorderAction]
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      displays: [newDisplay, initialDisplay],
+    }
+
+    const updatedState = actionsArray.reduce(reducer, state)
+    expect(updatedState).toEqual(expectedState)
+  })
+
+  it('should return state with reordered constant', () => {
+    const addAction: BuilderAction = {
+      type: BuilderActionEnum.Add,
+      payload: {
+        element: newConstant,
+        configArrName: ConfigArrayEnum.Constants,
+      },
+    }
+    const reorderAction: BuilderAction = {
+      type: BuilderActionEnum.Reorder,
+      payload: {
+        currIndex: initialElementIndex,
+        newIndex: finalElementIndex,
+        configArrName: ConfigArrayEnum.Constants,
+      },
+    }
+    const actionsArray = [addAction, reorderAction]
+    const state = initialChecker
+    const expectedState = {
+      ...initialChecker,
+      constants: [newConstant, initialConstant],
+    }
+
+    const updatedState = actionsArray.reduce(reducer, state)
+    expect(updatedState).toEqual(expectedState)
   })
 })

--- a/src/client/pages/Checker.tsx
+++ b/src/client/pages/Checker.tsx
@@ -27,7 +27,7 @@ const EXAMPLE: checker.Checker = {
       type: 'RADIO',
       description: 'Define b',
       help: '',
-      options: [{ value: 'Option 1' }, { value: 'Option 2' }],
+      options: [{ label: 'Option 1', value: 0 }, { label: 'Option 2', value: 1 }],
     },
   ],
   operations: [

--- a/src/client/pages/Checker.tsx
+++ b/src/client/pages/Checker.tsx
@@ -27,7 +27,10 @@ const EXAMPLE: checker.Checker = {
       type: 'RADIO',
       description: 'Define b',
       help: '',
-      options: [{ label: 'Option 1', value: 0 }, { label: 'Option 2', value: 1 }],
+      options: [
+        { label: 'Option 1', value: 0 },
+        { label: 'Option 2', value: 1 },
+      ],
     },
   ],
   operations: [

--- a/src/types/builder.d.ts
+++ b/src/types/builder.d.ts
@@ -1,12 +1,20 @@
 import { Field, Operation, Display, Constant, ConfigArrayName } from './checker'
 
-export type BuilderActionType = 'ADD' | 'REMOVE' | 'UPDATE' | 'REORDER'
+export type BuilderActionType =
+  | 'ADD'
+  | 'REMOVE'
+  | 'UPDATE'
+  | 'REORDER'
+  | 'UPDATE_SETTINGS'
 
-export type BuilderAddPayload =
+export type BuilderAddPayload = (
   | FieldPayload
   | OperationPayload
   | DisplayPayload
   | ConstantPayload
+) & {
+  newIndex: number
+}
 
 export type BuilderUpdatePayload = (
   | FieldPayload
@@ -48,6 +56,11 @@ export interface BuilderReorderPayload {
   configArrName: ConfigArrayName
 }
 
+export interface BuilderUpdateSettingsPayload {
+  settingsName: 'description' | 'title'
+  value: string
+}
+
 export interface BuilderAction {
   type: BuilderActionType
   payload:
@@ -55,4 +68,5 @@ export interface BuilderAction {
     | BuilderUpdatePayload
     | BuilderRemovePayload
     | BuilderReorderPayload
+    | BuilderUpdateSettingsPayload
 }

--- a/src/types/builder.d.ts
+++ b/src/types/builder.d.ts
@@ -1,0 +1,58 @@
+import { Field, Operation, Display, Constant, ConfigArrayName } from './checker'
+
+export type BuilderActionType = 'ADD' | 'REMOVE' | 'UPDATE' | 'REORDER'
+
+export type BuilderAddPayload =
+  | FieldPayload
+  | OperationPayload
+  | DisplayPayload
+  | ConstantPayload
+
+export type BuilderUpdatePayload = (
+  | FieldPayload
+  | OperationPayload
+  | DisplayPayload
+  | ConstantPayload
+) & {
+  currIndex: number
+}
+
+export interface FieldPayload {
+  configArrName: 'fields'
+  element: Field
+}
+
+export interface OperationPayload {
+  configArrName: 'operations'
+  element: Operation
+}
+
+export interface DisplayPayload {
+  configArrName: 'displays'
+  element: Display
+}
+
+export interface ConstantPayload {
+  configArrName: 'constants'
+  element: Constant
+}
+
+export interface BuilderRemovePayload {
+  currIndex: number
+  configArrName: ConfigArrayName
+}
+
+export interface BuilderReorderPayload {
+  currIndex: number
+  newIndex: number
+  configArrName: ConfigArrayName
+}
+
+export interface BuilderAction {
+  type: BuilderActionType
+  payload:
+    | BuilderAddPayload
+    | BuilderUpdatePayload
+    | BuilderRemovePayload
+    | BuilderReorderPayload
+}

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -20,7 +20,8 @@ export interface Field {
 }
 
 export interface FieldOption {
-  value: string
+  label: string,
+  value: number
 }
 
 export type FieldType = 'NUMERIC' | 'RADIO' | 'CHECKBOX' | 'SLIDER' | 'DATE'

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -20,7 +20,7 @@ export interface Field {
 }
 
 export interface FieldOption {
-  label: string,
+  label: string
   value: number
 }
 

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -9,6 +9,8 @@ export interface Checker {
   displays: Display[]
 }
 
+export type ConfigArrayName = 'fields' | 'operations' | 'displays' | 'constants'
+
 export interface Field {
   id: string
   type: FieldType

--- a/src/util/enums.ts
+++ b/src/util/enums.ts
@@ -3,6 +3,7 @@ export enum BuilderActionEnum {
   Remove = 'REMOVE',
   Update = 'UPDATE',
   Reorder = 'REORDER',
+  UpdateSettings = 'UPDATE_SETTINGS',
 }
 
 export enum ConfigArrayEnum {

--- a/src/util/enums.ts
+++ b/src/util/enums.ts
@@ -1,0 +1,13 @@
+export enum BuilderActionEnum {
+  Add = 'ADD',
+  Remove = 'REMOVE',
+  Update = 'UPDATE',
+  Reorder = 'REORDER',
+}
+
+export enum ConfigArrayEnum {
+  Fields = 'fields',
+  Operations = 'operations',
+  Displays = 'displays',
+  Constants = 'constants',
+}


### PR DESCRIPTION
This PR adds the reducer functionality to the checker builder as well as the relevant tests. 

Specifically, the reducer accepts 4 actions (`Add`, `Remove`, `Update`, and `Reorder`) and applies these reducer actions to any of the 4 config arrays (`fields`, `operations`, `displays`, `constants`).