### PR TITLE
Feat/add builder functionality

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -27,14 +27,12 @@ const App: FC = () => {
               <Route exact path="/login" component={Login} />
               <Route exact path="/" component={Landing} />
 
-              <Route exact path="/builder">
-                <CheckerProvider>
-                  <FormBuilder />
-                </CheckerProvider>
-              </Route>
-
               <PrivateRoute>
                 <Route exact path="/dashboard" component={Dashboard} />
+                {/* TO-DO: Rename CheckerProvider to BuilderProvider and context */}
+                <CheckerProvider>
+                  <Route exact path="/builder/:id" component={FormBuilder} />
+                </CheckerProvider>
               </PrivateRoute>
               <Redirect to="/" />
             </Switch>
@@ -44,5 +42,4 @@ const App: FC = () => {
     </ChakraProvider>
   )
 }
-
 export default App

--- a/src/client/components/builder/Navbar.tsx
+++ b/src/client/components/builder/Navbar.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import { BiArrowBack } from 'react-icons/bi'
+import { Link } from 'react-router-dom'
 import {
   Tabs,
   TabList,
@@ -35,8 +36,14 @@ export const Navbar: FC<NavbarProps> = ({
       zIndex={999}
     >
       <HStack>
-        <IconButton aria-label="Back" variant="ghost" icon={<BiArrowBack />} />
-        <Button variant="ghost">Untitled Project</Button>
+        <Link to={'/dashboard'}>
+          <IconButton
+            aria-label="Back"
+            variant="ghost"
+            icon={<BiArrowBack />}
+          />
+          <Button variant="ghost">Untitled Project</Button>
+        </Link>
       </HStack>
       <HStack h="100%" flex={1} justifyContent="center" spacing={0}>
         <Tabs

--- a/src/client/components/builder/Navbar.tsx
+++ b/src/client/components/builder/Navbar.tsx
@@ -15,11 +15,13 @@ import { LogoutButton } from '../LogoutButton'
 export type NavbarProps = {
   index: number
   onTabsChange: (index: number) => void
+  onSave: () => void
 }
 
 export const Navbar: FC<NavbarProps> = ({
   index,
   onTabsChange,
+  onSave,
 }: NavbarProps) => {
   return (
     <Flex
@@ -57,7 +59,9 @@ export const Navbar: FC<NavbarProps> = ({
         </Tabs>
       </HStack>
       <HStack>
-        <Button colorScheme="primary">Save</Button>
+        <Button colorScheme="primary" onClick={onSave}>
+          Save
+        </Button>
         <LogoutButton />
       </HStack>
     </Flex>

--- a/src/client/components/builder/TitleField.tsx
+++ b/src/client/components/builder/TitleField.tsx
@@ -17,9 +17,7 @@ const InputComponent: TitleFieldComponent = ({ title, description }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     const update = { settingsName: name as SettingsName, value }
-    // TODO: Dispatch value to save new title and description
 
-    console.log(update, 'my title field changed')
     dispatch({
       type: BuilderActionEnum.UpdateSettings,
       payload: update,

--- a/src/client/components/dashboard/CheckerCard.tsx
+++ b/src/client/components/dashboard/CheckerCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FC } from 'react'
 import { BiDuplicate, BiTrash } from 'react-icons/bi'
+import { Link } from 'react-router-dom'
 import {
   useMultiStyleConfig,
   useDisclosure,
@@ -47,16 +48,18 @@ export const CheckerCard: FC<CheckerCardProps> = ({
         onMouseOut={() => setToolbarVisible('hidden')}
         sx={styles.card}
       >
-        <Text sx={styles.title}>{checker.title}</Text>
-        <HStack
-          visibility={isToolbarVisible}
-          mt="50px"
-          mb="35px"
-          justifyContent="center"
-        >
-          <BiDuplicate onClick={onOpen} size="24px" />
-          <BiTrash onClick={onClickDelete} size="24px" />
-        </HStack>
+        <Link to={`/builder/${checker.id}`}>
+          <Text sx={styles.title}>{checker.title}</Text>
+          <HStack
+            visibility={isToolbarVisible}
+            mt="50px"
+            mb="35px"
+            justifyContent="center"
+          >
+            <BiDuplicate onClick={onOpen} size="24px" />
+            <BiTrash onClick={onClickDelete} size="24px" />
+          </HStack>
+        </Link>
       </Box>
       <CreateNewModal
         isOpen={isOpen}

--- a/src/client/pages/FormBuilder.tsx
+++ b/src/client/pages/FormBuilder.tsx
@@ -1,14 +1,52 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import { Tabs, TabPanels, TabPanel, Flex } from '@chakra-ui/react'
+import { useCheckerContext } from '../../client/contexts/CheckerContext'
 
 import { Navbar, QuestionsTab, LogicTab } from '../components/builder'
 
-export const FormBuilder: FC = () => {
+// from typings
+import * as H from 'history'
+
+interface matchParams {
+  id: string
+}
+
+interface RouteComponentProps<P> {
+  match: match<P>
+  location: H.Location
+  history: H.History
+  staticContext?: any
+}
+
+interface match<P> {
+  params: P
+  isExact: boolean
+  path: string
+  url: string
+}
+
+export const FormBuilder: FC<RouteComponentProps<matchParams>> = ({
+  match,
+}) => {
+  const { id } = match.params
   const [tabIndex, setTabIndex] = useState(0)
+  const { initChecker, save } = useCheckerContext()
+
+  /* eslint-disable */
+  useEffect(() => {
+    (async function () {
+      await initChecker(id)
+    })()
+  }, [])
+  /* eslint-enable */
+
+  const onSave = async () => {
+    await save(id)
+  }
 
   return (
     <Flex direction="column" minH="100vh" bgColor="#F4F6F9">
-      <Navbar index={tabIndex} onTabsChange={setTabIndex} />
+      <Navbar index={tabIndex} onTabsChange={setTabIndex} onSave={onSave} />
       <Tabs index={tabIndex} mt="80px">
         <TabPanels>
           <TabPanel>

--- a/src/types/builder.d.ts
+++ b/src/types/builder.d.ts
@@ -1,4 +1,11 @@
-import { Field, Operation, Display, Constant, ConfigArrayName } from './checker'
+import {
+  Field,
+  Operation,
+  Display,
+  Constant,
+  ConfigArrayName,
+  Checker,
+} from './checker'
 
 export type BuilderActionType =
   | 'ADD'
@@ -6,6 +13,7 @@ export type BuilderActionType =
   | 'UPDATE'
   | 'REORDER'
   | 'UPDATE_SETTINGS'
+  | 'LOAD_CONFIG'
 
 export type BuilderAddPayload = (
   | FieldPayload
@@ -61,6 +69,10 @@ export interface BuilderUpdateSettingsPayload {
   value: string
 }
 
+export interface BuilderLoadConfigPayload {
+  loadedState: Checker
+}
+
 export interface BuilderAction {
   type: BuilderActionType
   payload:
@@ -69,4 +81,5 @@ export interface BuilderAction {
     | BuilderRemovePayload
     | BuilderReorderPayload
     | BuilderUpdateSettingsPayload
+    | BuilderLoadConfigPayload
 }

--- a/src/util/enums.ts
+++ b/src/util/enums.ts
@@ -4,6 +4,7 @@ export enum BuilderActionEnum {
   Update = 'UPDATE',
   Reorder = 'REORDER',
   UpdateSettings = 'UPDATE_SETTINGS',
+  LoadConfig = 'LOAD_CONFIG',
 }
 
 export enum ConfigArrayEnum {


### PR DESCRIPTION
This PR achieves the following:
- Modifies the builder frontend route to be `/builder/:checker-id`
- Allow the builder to call the save and retrieve endpoints
- Links up the dashboard to the builder page