### PR TITLE
feat(checker): authenticate user before operations

### DIFF
--- a/src/server/checker/__test__/CheckerController.spec.ts
+++ b/src/server/checker/__test__/CheckerController.spec.ts
@@ -69,4 +69,199 @@ describe('CheckerController', () => {
       expect(service.create).toHaveBeenCalledWith(checker, user)
     })
   })
+
+  describe('list', () => {
+    const user = { id: 1, email: 'user@agency.gov.sg' }
+    const app = express()
+    app.use(bodyParser.json())
+    app.use(sessionMiddleware({ user }))
+    app.get('/c', controller.list)
+
+    beforeEach(() => {
+      service.list.mockReset()
+    })
+
+    it('rejects non-authenticated listing', async () => {
+      const app = express()
+      app.use(bodyParser.json())
+      app.use(sessionMiddleware({}))
+      app.get('/c', controller.list)
+      await request(app).get('/c').expect(401)
+    })
+
+    it('allows authenticated listing', async () => {
+      const checker = { id: 'id', title: 'title' }
+      service.list.mockResolvedValue([checker])
+      const response = await request(app).get('/c').expect(200)
+      expect(response.body).toStrictEqual([checker])
+      expect(service.list).toHaveBeenCalledWith(user)
+    })
+
+    it('returns error on listing exception', async () => {
+      const message = 'An error message'
+      service.list.mockRejectedValue(new Error(message))
+      const response = await request(app).get('/c').expect(400)
+      expect(response.body).toStrictEqual({ message })
+      expect(service.list).toHaveBeenCalledWith(user)
+    })
+  })
+
+  describe('get', () => {
+    const user = { id: 1, email: 'user@agency.gov.sg' }
+    const app = express()
+    app.use(bodyParser.json())
+    app.use(sessionMiddleware({ user }))
+    app.get('/c/:id', controller.get)
+
+    beforeEach(() => {
+      service.retrieve.mockReset()
+    })
+
+    it('accepts non-authenticated get', async () => {
+      const app = express()
+      app.use(bodyParser.json())
+      app.use(sessionMiddleware({}))
+      app.get('/c/:id', controller.get)
+
+      const checker = { id: 'id', title: 'title' }
+      service.retrieve.mockResolvedValue(checker)
+      const response = await request(app).get(`/c/${checker.id}`).expect(200)
+      expect(response.body).toStrictEqual(checker)
+      expect(service.retrieve).toHaveBeenCalledWith(checker.id, undefined)
+    })
+
+    it('allows authenticated get', async () => {
+      const checker = { id: 'id', title: 'title' }
+      service.retrieve.mockResolvedValue(checker)
+      const response = await request(app).get(`/c/${checker.id}`).expect(200)
+      expect(response.body).toStrictEqual(checker)
+      expect(service.retrieve).toHaveBeenCalledWith(checker.id, user)
+    })
+
+    it('returns 404 on Not Found', async () => {
+      const id = 'missing'
+      service.retrieve.mockResolvedValue(undefined)
+      await request(app).get(`/c/${id}`).expect(404)
+      expect(service.retrieve).toHaveBeenCalledWith(id, user)
+    })
+
+    it('returns error on get exception', async () => {
+      const id = 'bad'
+      const message = 'An error message'
+      service.retrieve.mockRejectedValue(new Error(message))
+      const response = await request(app).get(`/c/${id}`).expect(400)
+      expect(response.body).toStrictEqual({ message })
+      expect(service.retrieve).toHaveBeenCalledWith(id, user)
+    })
+  })
+
+  describe('put', () => {
+    const user = { id: 1, email: 'user@agency.gov.sg' }
+    const app = express()
+    app.use(bodyParser.json())
+    app.use(sessionMiddleware({ user }))
+    app.put('/c/:id', controller.put)
+
+    beforeEach(() => {
+      service.update.mockReset()
+    })
+
+    it('rejects non-authenticated put', async () => {
+      const app = express()
+      app.use(bodyParser.json())
+      app.use(sessionMiddleware({}))
+      app.put('/c/:id', controller.put)
+
+      const checker = { id: 'id', title: 'title' }
+      service.update.mockResolvedValue(1)
+
+      await request(app).put(`/c/${checker.id}`).send(checker).expect(401)
+      expect(service.update).not.toHaveBeenCalled()
+    })
+
+    it('accepts authenticated put', async () => {
+      const checker = { id: 'id', title: 'title' }
+      service.update.mockResolvedValue(checker)
+      const response = await request(app)
+        .put(`/c/${checker.id}`)
+        .send(checker)
+        .expect(200)
+      expect(response.body).toStrictEqual(checker)
+      expect(service.update).toHaveBeenCalledWith(checker.id, checker, user)
+    })
+
+    it('returns 404 on put Not Found', async () => {
+      const checker = { id: 'id', title: 'title' }
+      service.update.mockResolvedValue(0)
+      await request(app).put(`/c/${checker.id}`).send(checker).expect(404)
+      expect(service.update).toHaveBeenCalledWith(checker.id, checker, user)
+    })
+
+    it('returns error on put exception', async () => {
+      const checker = { id: 'id', title: 'title' }
+      const message = 'An error message'
+      service.update.mockRejectedValue(new Error(message))
+      const response = await request(app)
+        .put(`/c/${checker.id}`)
+        .send(checker)
+        .expect(400)
+      expect(response.body).toStrictEqual({ message })
+      expect(service.update).toHaveBeenCalledWith(checker.id, checker, user)
+    })
+  })
+
+  describe('delete', () => {
+    const user = { id: 1, email: 'user@agency.gov.sg' }
+    const app = express()
+    app.use(bodyParser.json())
+    app.use(sessionMiddleware({ user }))
+    app.delete('/c/:id', controller.delete)
+
+    beforeEach(() => {
+      service.delete.mockReset()
+    })
+
+    it('rejects non-authenticated delete', async () => {
+      const app = express()
+      app.use(bodyParser.json())
+      app.use(sessionMiddleware({}))
+      app.delete('/c/:id', controller.delete)
+
+      const checker = { id: 'id', title: 'title' }
+      service.delete.mockResolvedValue(1)
+
+      await request(app).delete(`/c/${checker.id}`).send(checker).expect(401)
+      expect(service.delete).not.toHaveBeenCalled()
+    })
+
+    it('accepts authenticated delete', async () => {
+      const checker = { id: 'id', title: 'title' }
+      service.delete.mockResolvedValue(checker)
+      const response = await request(app)
+        .delete(`/c/${checker.id}`)
+        .send(checker)
+        .expect(200)
+      expect(response.body).toMatchObject({ message: expect.any(String) })
+      expect(service.delete).toHaveBeenCalledWith(checker.id, user)
+    })
+
+    it('returns 404 on delete Not Found', async () => {
+      const checker = { id: 'id', title: 'title' }
+      service.delete.mockResolvedValue(0)
+      await request(app).delete(`/c/${checker.id}`).send(checker).expect(404)
+      expect(service.delete).toHaveBeenCalledWith(checker.id, user)
+    })
+
+    it('returns error on delete exception', async () => {
+      const checker = { id: 'id', title: 'title' }
+      const message = 'An error message'
+      service.delete.mockRejectedValue(new Error(message))
+      const response = await request(app)
+        .delete(`/c/${checker.id}`)
+        .send(checker)
+        .expect(400)
+      expect(response.body).toStrictEqual({ message })
+      expect(service.delete).toHaveBeenCalledWith(checker.id, user)
+    })
+  })
 })

--- a/src/server/checker/__test__/CheckerService.spec.ts
+++ b/src/server/checker/__test__/CheckerService.spec.ts
@@ -13,53 +13,52 @@ describe('CheckerService', () => {
 
   const service = new CheckerService({ sequelize, User, Checker })
 
-  beforeEach(async () => {
+  const user = { id: 1, email: 'user@agency.gov.sg' }
+  const checker = {
+    id: 'existing-checker',
+    title: 'Existing Checker',
+    fields: [],
+    constants: [],
+    operations: [],
+    displays: [],
+  }
+
+  const anotherUser = { id: 2, email: 'another-user@agency.gov.sg' }
+  const anotherChecker = {
+    id: 'another-checker',
+    title: 'Another Checker',
+    fields: [],
+    constants: [],
+    operations: [],
+    displays: [],
+  }
+
+  beforeAll(async () => {
     await sequelizeReady
   })
 
   describe('create', () => {
-    const user = { id: 1, email: 'user@agency.gov.sg' }
     beforeEach(async () => {
       await Checker.destroy({ truncate: true })
       await User.destroy({ truncate: true })
     })
     it('returns false if checker exists', async () => {
-      const checker = {
-        id: 'existing-checker',
-        title: 'Existing Checker',
-        fields: [],
-        constants: [],
-        operations: [],
-        displays: [],
-      }
       await Checker.create(checker)
+
       const created = await service.create(checker, user)
+
       expect(created).toBe(false)
     })
 
     it('throws error if user does not exist', async () => {
-      const checker = {
-        id: 'existing-checker',
-        title: 'Existing Checker',
-        fields: [],
-        constants: [],
-        operations: [],
-        displays: [],
-      }
       await expect(() => service.create(checker, user)).rejects.toThrowError()
     })
 
     it('successfully creates a checker', async () => {
-      const checker = {
-        id: 'existing-checker',
-        title: 'Existing Checker',
-        fields: [],
-        constants: [],
-        operations: [],
-        displays: [],
-      }
       await User.create(user)
+
       const created = await service.create(checker, user)
+
       expect(created).toBe(true)
       const checkerInstance = await Checker.findByPk(checker.id, {
         include: [User],
@@ -69,6 +68,132 @@ describe('CheckerService', () => {
       expect(actualChecker?.users).toBeDefined()
       const [actualUser] = actualChecker?.users as Record<string, unknown>[]
       expect(actualUser).toMatchObject(user)
+    })
+  })
+
+  describe('list', () => {
+    beforeEach(async () => {
+      await Checker.destroy({ truncate: true })
+      await User.destroy({ truncate: true })
+    })
+    it("lists users' respective checkers", async () => {
+      await User.create(user)
+      await User.create(anotherUser)
+      await service.create(checker, user)
+      await service.create(anotherChecker, anotherUser)
+
+      const [actualChecker, ...rest] = await service.list(user)
+      const [actualAnotherChecker, ...anotherRest] = await service.list(
+        anotherUser
+      )
+
+      expect(actualChecker).toMatchObject(checker)
+      expect(actualAnotherChecker).toMatchObject(anotherChecker)
+      expect(rest).toStrictEqual([])
+      expect(anotherRest).toStrictEqual([])
+    })
+  })
+
+  describe('retrieve', () => {
+    beforeAll(async () => {
+      await Checker.destroy({ truncate: true })
+      await User.destroy({ truncate: true })
+      await User.create(user)
+      await User.create(anotherUser)
+      await service.create(checker, user)
+    })
+
+    it("retrieves users' checker with user info if user", async () => {
+      const actualChecker = await service.retrieve(checker.id, user)
+
+      expect(actualChecker).toMatchObject({
+        ...checker,
+        users: expect.arrayContaining([expect.objectContaining(user)]),
+      })
+    })
+
+    it("retrieves users' checker without user info if another user", async () => {
+      const actualChecker = await service.retrieve(checker.id, anotherUser)
+
+      expect(actualChecker).toMatchObject(checker)
+      expect(actualChecker?.users).not.toBeDefined()
+    })
+
+    it("retrieves users' checker without user info if anonymous", async () => {
+      const actualChecker = await service.retrieve(checker.id)
+
+      expect(actualChecker).toMatchObject(checker)
+      expect(actualChecker?.users).not.toBeDefined()
+    })
+  })
+
+  describe('update', () => {
+    const change = { description: 'New Description' }
+
+    beforeAll(async () => {
+      await User.destroy({ truncate: true })
+      await User.create(user)
+      await User.create(anotherUser)
+    })
+    beforeEach(async () => {
+      await Checker.destroy({ truncate: true })
+      await service.create(checker, user)
+    })
+
+    it('effects no change if id not found', async () => {
+      const count = await service.update(anotherChecker.id, change, user)
+      expect(count).toBe(0)
+      const checkerInstance = await Checker.findByPk(checker.id)
+      expect(checkerInstance).toMatchObject(checker)
+    })
+
+    it('throws if unauthorized user', async () => {
+      await expect(
+        service.update(checker.id, change, anotherUser)
+      ).rejects.toMatchObject(new Error('Unauthorized'))
+      const checkerInstance = await Checker.findByPk(checker.id)
+      expect(checkerInstance).toMatchObject(checker)
+    })
+
+    it('effects change if id found and correct user', async () => {
+      const count = await service.update(checker.id, change, user)
+      expect(count).toBe(1)
+      const checkerInstance = await Checker.findByPk(checker.id)
+      expect(checkerInstance).toMatchObject({ ...checker, ...change })
+    })
+  })
+
+  describe('delete', () => {
+    beforeAll(async () => {
+      await User.destroy({ truncate: true })
+      await User.create(user)
+      await User.create(anotherUser)
+    })
+    beforeEach(async () => {
+      await Checker.destroy({ truncate: true })
+      await service.create(checker, user)
+    })
+
+    it('does not delete if id not found', async () => {
+      const count = await service.delete(anotherChecker.id, user)
+      expect(count).toBe(0)
+      const checkerInstance = await Checker.findByPk(checker.id)
+      expect(checkerInstance).toMatchObject(checker)
+    })
+
+    it('throws if delete by unauthorized user', async () => {
+      await expect(
+        service.delete(checker.id, anotherUser)
+      ).rejects.toMatchObject(new Error('Unauthorized'))
+      const checkerInstance = await Checker.findByPk(checker.id)
+      expect(checkerInstance).toMatchObject(checker)
+    })
+
+    it('deletes if id found and correct user', async () => {
+      const count = await service.delete(checker.id, user)
+      expect(count).toBe(1)
+      const checkerInstance = await Checker.findByPk(checker.id)
+      expect(checkerInstance).toBeNull()
     })
   })
 })

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -1,7 +1,10 @@
+import { User } from './user'
+
 export interface Checker {
   id: string
   title: string
   description?: string
+  users?: User[]
 
   fields: Field[]
   constants: Constant[]


### PR DESCRIPTION
## Problem

Checkers are freely accessible by all because there is no user authorization checks actually being done

## Solution

- Ensure the user can update/delete the checker
- Ensure the user lists only the checkers he/she has access to
- When retrieving a checker, if anonymous or user with no access to
  checker, return the checker without user information
- Similarly, if user is retrieving his/her own checker, add user
  information
