### PR TITLE
fix: prevent restart of field numbering when reloading page

### DIFF
--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -41,8 +41,8 @@ export const LogicTab: FC = () => {
 
   useEffect(() => {
     let highestIndex = 0
-    config.operations.forEach((field) => {
-      const operationIndex = parseInt(field.id.slice(1))
+    config.operations.forEach((operation) => {
+      const operationIndex = parseInt(operation.id.slice(1))
       highestIndex = Math.max(highestIndex, operationIndex)
     })
     setNextUniqueId(highestIndex + 1)

--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import {
   BiPlusCircle,
   BiCalculator,
@@ -38,6 +38,15 @@ export const LogicTab: FC = () => {
   const [offsetTop, setOffsetTop] = useState<number>(16)
   const [nextUniqueId, setNextUniqueId] = useState<number>(1)
   const { dispatch, config } = useCheckerContext()
+
+  useEffect(() => {
+    let highestIndex = 0
+    config.operations.forEach((field) => {
+      const operationIndex = parseInt(field.id.slice(1))
+      highestIndex = Math.max(highestIndex, operationIndex)
+    })
+    setNextUniqueId(highestIndex + 1)
+  }, [])
 
   const addMenu = [
     {
@@ -97,7 +106,7 @@ export const LogicTab: FC = () => {
           payload: {
             currIndex: activeIndex,
             newIndex: activeIndex + 1,
-            configArrName: ConfigArrayEnum.Fields,
+            configArrName: ConfigArrayEnum.Operations,
           },
         })
         setActiveIndex(activeIndex + 1)

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import {
   BiHash,
   BiRadioCircleMarked,
@@ -63,6 +63,15 @@ export const QuestionsTab: FC = () => {
   const { config, dispatch } = useCheckerContext()
 
   const { title, description, fields } = config
+
+  useEffect(() => {
+    let highestIndex = 0
+    config.fields.forEach((field) => {
+      const fieldIndex = parseInt(field.id.slice(1))
+      highestIndex = Math.max(highestIndex, fieldIndex)
+    })
+    setNextUniqueId(highestIndex + 1)
+  }, [])
 
   const toolbarOptions = [
     {


### PR DESCRIPTION
This PR fixes a bug where the numbering of fields and operations would restart upon reloading the page. We now look through the existing items in fields/operations to determine the appropriate index to use.

This PR also fixes a minor bug involving the reordering of operations when moving down.