### PR TITLE
fix: ensure that NumericField values type number instead of string

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -57,7 +57,20 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
     )
   }
 
+  // An input variable is a numeric field if its key name starts with N
+  const isNumericField = (key: string) => {
+    return key[0] === 'N'
+  }
+
   const onSubmit = (inputs: Record<string, string | number>) => {
+    // Set all numeric inputs to type Number
+    const parsedInputs: Record<string, string | number> = {}
+    Object.keys(inputs).forEach((key: string) => {
+      parsedInputs[key] = isNumericField(key)
+        ? Number(inputs[key])
+        : inputs[key]
+    })
+
     if (!isCheckerComplete()) {
       toast({
         status: 'warning',
@@ -67,7 +80,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
       })
     }
 
-    const computed = evaluate(inputs, constants, operations)
+    const computed = evaluate(parsedInputs, constants, operations)
     setVariables(computed)
     outcomes.current?.scrollIntoView()
   }


### PR DESCRIPTION
## Problem

Currently, the `NumericField` value type in the Checker object is `string`, when it should actually be `number`. This results in admin users having to specify string comparisons in the IF/ELSE Logic builder statements (as shown in the image below).

![image](https://user-images.githubusercontent.com/19917616/105958295-654fae80-60b5-11eb-9e64-8318180ef358.png)


## Solution

The solution is to iterate through all `inputs` provided when the citizen user hits the submit button and casting the `NumericField` value as `number`.

I attempted to explore alternative solutions - such as by attempting to set the underlying `type` of the HTML Input element to `number` via ChakraUI. However, ChakraUI's `NumberInput` does not allow us to set the underlying Input `type` directly, and the `NumberInput`'s `value` and `onChange` type is `number | string` ([source](https://github.com/chakra-ui/chakra-ui/issues/278)).
