### PR TITLE
fix: return option labels instead of values for Radio and Checkbox fields

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -57,18 +57,28 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
     )
   }
 
-  // An input variable is a numeric field if its key name starts with N
-  const isNumericField = (key: string) => {
-    return key[0] === 'N'
-  }
-
   const onSubmit = (inputs: Record<string, string | number>) => {
     // Set all numeric inputs to type Number
     const parsedInputs: Record<string, string | number> = {}
-    Object.keys(inputs).forEach((key: string) => {
-      parsedInputs[key] = isNumericField(key)
-        ? Number(inputs[key])
-        : inputs[key]
+
+    fields.forEach((field) => {
+      const { id, type, options } = field
+      if (!inputs[id]) return
+
+      switch (type) {
+        case 'NUMERIC': {
+          return (parsedInputs[id] = Number(inputs[id]))
+        }
+        case 'RADIO': {
+          return (parsedInputs[id] = options[Number(inputs[id])].label)
+        }
+        case 'CHECKBOX': {
+          const checkboxValues = Object.values(inputs[id]).map(
+            (optionIndex) => options[optionIndex].label
+          )
+          return (parsedInputs[id] = JSON.stringify(checkboxValues))
+        }
+      }
     })
 
     if (!isCheckerComplete()) {


### PR DESCRIPTION
This PR applies a transformation step to the field input values for the Radio and Checkbox fields.

**Radio**
Currently, the input value of the radio field is the `value` (index) of the selected option, e.g. `"0"`. The new change applies a transformation to set the input value as the `label` of the selected option label, e.g. `"Option A"`.

**Checkbox**
Currently, the input value of the checkbox field is an array of selected option `value`, e.g. `["0", "1"]`. The new change a transformation to set the input value as a serialized string representing the array of selected option labels, e.g. `"[\"Option A\",\"Option B\"]"`