### PR TITLE
feat(sqlite): persist to file

### DIFF
--- a/src/server/bootstrap/sequelize.ts
+++ b/src/server/bootstrap/sequelize.ts
@@ -4,12 +4,16 @@ import logger from './logger'
 import config from '../config'
 
 const databaseUrl = config.get('databaseUrl')
+const sqlitePath = config.get('sqlitePath')
 
 export const sequelize = databaseUrl
   ? new Sequelize(databaseUrl, {
       timezone: '+08:00',
       logging: logger.info.bind(logger),
     })
-  : new Sequelize({ dialect: 'sqlite' })
+  : new Sequelize({
+      dialect: 'sqlite',
+      ...(sqlitePath ? { storage: sqlitePath } : {}),
+    })
 
 export default sequelize

--- a/src/server/checker/CheckerService.ts
+++ b/src/server/checker/CheckerService.ts
@@ -25,19 +25,24 @@ export class CheckerService {
     checker,
     user
   ) => {
+    const isSqliteFile =
+      this.sequelize.getDialect() === 'sqlite' &&
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ((this.sequelize as unknown) as Record<string, unknown>).options.storage
     const transaction = await this.sequelize.transaction()
+    const options = isSqliteFile ? {} : { transaction }
     try {
-      const existingChecker = await this.CheckerModel.findByPk(checker.id, {
-        transaction,
-      })
+      const existingChecker = await this.CheckerModel.findByPk(
+        checker.id,
+        options
+      )
       if (!existingChecker) {
         const userInstance = await this.UserModel.findByPk(user.id)
         if (!userInstance) {
           throw new Error(`User ${user.id} [${user.email}] not found`)
         }
-        const checkerInstance = await this.CheckerModel.create(checker, {
-          transaction,
-        })
+        const checkerInstance = await this.CheckerModel.create(checker, options)
         // We definitely know that userInstance can add associations
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await (userInstance as any).addChecker(checkerInstance)

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -44,11 +44,17 @@ const config = convict({
     doc: 'The maximum age for a cookie, expressed in ms',
     env: 'COOKIE_MAX_AGE',
     format: 'int',
-    default: 1800000, // 30 minutes
+    default: 14400000, // 4 hours
   },
   // TODO - change the secrets below so that the defaults have
   // production-appropriate defaults, or no defaults at all, per
   // guidelines for using convict
+  sqlitePath: {
+    doc: 'The path of the sqlite data file, or blank if in-memory',
+    env: 'SQLITE_PATH',
+    format: '*',
+    default: '/tmp/checkfirst.db',
+  },
   otpSecret: {
     doc: 'A secret string used to generate TOTPs for users',
     env: 'OTP_SECRET',


### PR DESCRIPTION
## Problem

When run on local machine, sqlite needs to persist data between runs

## Solution

By default, persist sqlite data to disk, path specified by
`SQLITE_PATH`. If that path is an empty string, assume storage
is in-memory

- Declare a new env var, `SQLITE_PATH`, default `/tmp/checkfirst.db`
- When creating a Sequelize instance, for the sqlite dialect, if
  an empty `SQLITE_PATH` is given, assume that in-memory storage
  is desired (ie, the sequelize default)
- Because sqlite does not handle transaction locking very well (eg,
  a txn cannot write to a table if it the same txn has locked it for
  reading), detect if sequelize is using sqlite backed by a file,
  and avoid using a transaction if so

- Take the trouble to extend cookie age to 4 hours

**New environment variables**:

- `SQLITE_PATH` : the file to persist sqlite data to, or blank if in-memory preferred
