### PR TITLE
fix: add unique id logic when duplication fields/operations

### DIFF
--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -53,9 +53,11 @@ interface BuilderFieldProps {
   index: number
   active?: boolean
   data: BuilderFieldData
+  nextUniqueId: number
   onSelect: ({ index }: { index: number }) => void
   onActive: ({ top }: { top: number }) => void
   setActiveIndex: (index: number) => void
+  setNextUniqueId: (index: number) => void
 }
 
 export const createBuilderField = (
@@ -68,6 +70,8 @@ export const createBuilderField = (
   onSelect,
   onActive,
   setActiveIndex,
+  nextUniqueId,
+  setNextUniqueId,
   ...props
 }) => {
   const [ref, { top }] = usePosition()
@@ -111,24 +115,35 @@ export const createBuilderField = (
 
   const handleDuplicate = () => {
     if (isFieldData(data)) {
+      const updatedData = {
+        ...data,
+        id: `${data.id[0]}${nextUniqueId}`,
+      }
       dispatch({
         type: BuilderActionEnum.Add,
         payload: {
-          element: data,
+          element: updatedData,
           configArrName: ConfigArrayEnum.Fields,
           newIndex: index + 1,
         },
       })
       setActiveIndex(index + 1)
+      setNextUniqueId(nextUniqueId + 1)
     } else if (isOperationData(data)) {
+      const updatedData = {
+        ...data,
+        id: `${data.id[0]}${nextUniqueId}`,
+      }
       dispatch({
         type: BuilderActionEnum.Add,
         payload: {
-          element: data,
+          element: updatedData,
           configArrName: ConfigArrayEnum.Operations,
           newIndex: index + 1,
         },
       })
+      setActiveIndex(index + 1)
+      setNextUniqueId(nextUniqueId + 1)
     }
   }
 

--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -148,6 +148,8 @@ export const LogicTab: FC = () => {
       onActive,
       onSelect,
       setActiveIndex,
+      nextUniqueId,
+      setNextUniqueId,
     }
 
     switch (op.type) {

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -71,7 +71,7 @@ export const QuestionsTab: FC = () => {
       highestIndex = Math.max(highestIndex, fieldIndex)
     })
     setNextUniqueId(highestIndex + 1)
-  }, [])
+  }, [config])
 
   const toolbarOptions = [
     {

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -181,6 +181,8 @@ export const QuestionsTab: FC = () => {
       onActive,
       onSelect,
       setActiveIndex,
+      nextUniqueId,
+      setNextUniqueId,
     }
 
     switch (field.type) {
@@ -204,6 +206,8 @@ export const QuestionsTab: FC = () => {
         onActive={onActive}
         index={TITLE_FIELD_INDEX}
         setActiveIndex={setActiveIndex}
+        nextUniqueId={nextUniqueId}
+        setNextUniqueId={setNextUniqueId}
       />
       {fields.map(renderField)}
     </VStack>


### PR DESCRIPTION
This PR fixes a minor bug involving duplicate ids when duplicating fields and operations.