### PR TITLE
fix: parsing error that causes application to crash

### DIFF
--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -51,21 +51,21 @@ const fromExpression = (expression: string): IfelseState => {
     const parts = conditionExpr.replace(/\b(and|or)\b/g, '#$1').split('#')
 
     const conditions = parts.slice(1).map((p) => {
-      const partMatch = p.match(/\b(and|or)\b\s\((.*?)\)/)
+      const partMatch = p.match(/\b(and|or)\b\s?\((.*?)\)/)
       if (!partMatch) throw new Error('Invalid expression')
 
       const { 1: boolOperator, 2: subExpr } = partMatch
       return {
         type: boolOperator.toUpperCase(),
-        expression: subExpr,
+        expression: subExpr.trim(),
       } as Condition
     })
 
     return {
-      ifExpr: parts[0],
+      ifExpr: parts[0].trim(),
       conditions,
-      elseExpr,
-      thenExpr,
+      elseExpr: elseExpr.trim(),
+      thenExpr: thenExpr.trim(),
     }
   }
 


### PR DESCRIPTION
## Problem

When if expression if empty, the application crashes because the first `and` or `or` condition gets collapsed to a function call (e.g. `and(2 == 2)` instead of `1 == 1 and (2 == 2)`)

Closes [insert issue #]

## Solution

**Bug Fixes**:
- Relax the regex expression to allow for an optional space between the `and` and `or` operators to support both forms. This is a stop-gap fix that might need to be re-looked in the future.