### PR TITLE
feat: add map result to the logic tab

### DIFF
--- a/src/client/components/builder/FloatingToolbar.tsx
+++ b/src/client/components/builder/FloatingToolbar.tsx
@@ -12,6 +12,7 @@ interface ToolbarMenuItem {
   label: string
   icon: React.ReactElement
   onClick?: React.MouseEventHandler
+  disabled?: boolean
 }
 
 interface ToolbarOptions {
@@ -89,7 +90,7 @@ export const FloatingToolbar: FC<FloatingToolbarProps> = ({
       </VStack>
       {menu && (
         <VStack sx={styles.container} spacing={0}>
-          {menu.map(({ label, icon, onClick }, i) => (
+          {menu.map(({ label, icon, onClick, disabled }, i) => (
             <Button
               key={i}
               variant="ghost"
@@ -97,6 +98,7 @@ export const FloatingToolbar: FC<FloatingToolbarProps> = ({
               leftIcon={icon}
               iconSpacing={2}
               onClick={onClick}
+              isDisabled={disabled}
             >
               {label}
             </Button>

--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -5,6 +5,7 @@ import {
   BiGitBranch,
   BiUpArrowAlt,
   BiDownArrowAlt,
+  BiGitCompare,
 } from 'react-icons/bi'
 import {
   Center,
@@ -22,7 +23,11 @@ import {
 import { useCheckerContext } from '../../contexts'
 import * as checker from '../../../types/checker'
 import { FloatingToolbar } from '../builder'
-import { CalculatedResult, ConditionalResult } from '../builder/logic'
+import {
+  CalculatedResult,
+  ConditionalResult,
+  MapResult,
+} from '../builder/logic'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
 
 const generateDefaultArithmeticOp = (id: number): checker.Operation => ({
@@ -38,6 +43,14 @@ const generateDefaultIfelseOp = (id: number): checker.Operation => ({
   type: 'IFELSE',
   title: 'Conditional result',
   expression: 'ifelse(1 > 0, true, false)',
+  show: true,
+})
+
+const generateDefaultMapOp = (id: number): checker.Operation => ({
+  id: `O${id}`,
+  type: 'MAP',
+  title: 'Map constant',
+  expression: '0',
   show: true,
 })
 
@@ -81,6 +94,23 @@ export const LogicTab: FC = () => {
           type: BuilderActionEnum.Add,
           payload: {
             element: generateDefaultIfelseOp(nextUniqueId),
+            configArrName: ConfigArrayEnum.Operations,
+            newIndex: activeIndex + 1,
+          },
+        })
+        setActiveIndex(activeIndex + 1)
+        setNextUniqueId(nextUniqueId + 1)
+      },
+    },
+    {
+      label: 'Map constant',
+      icon: <BiGitCompare />,
+      disabled: config.constants.length === 0,
+      onClick: () => {
+        dispatch({
+          type: BuilderActionEnum.Add,
+          payload: {
+            element: generateDefaultMapOp(nextUniqueId),
             configArrName: ConfigArrayEnum.Operations,
             newIndex: activeIndex + 1,
           },
@@ -157,6 +187,8 @@ export const LogicTab: FC = () => {
         return <CalculatedResult {...commonProps} />
       case 'IFELSE':
         return <ConditionalResult {...commonProps} />
+      case 'MAP':
+        return <MapResult {...commonProps} />
     }
   }
 

--- a/src/client/components/builder/logic/MapResult.tsx
+++ b/src/client/components/builder/logic/MapResult.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useEffect } from 'react'
+import { isValidExpression, math } from '../../../core/evaluator'
+import update from 'immutability-helper'
+import { BiGitCompare, BiChevronDown } from 'react-icons/bi'
+import {
+  Badge,
+  Button,
+  VStack,
+  HStack,
+  Box,
+  Text,
+  Input,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+} from '@chakra-ui/react'
+
+import { useCheckerContext } from '../../../contexts'
+import { createBuilderField, OperationFieldComponent } from '../BuilderField'
+import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+
+interface MapState {
+  tableId: string
+  variableId: string
+}
+
+const EMPTY_STATE: MapState = {
+  tableId: '',
+  variableId: '',
+}
+
+const fromExpression = (expression: string) => {
+  const root = math.parse!(expression)
+  const args: string[] = []
+  root.forEach((node) => args.push(node.toString()))
+
+  if (root.isAccessorNode && args.length === 2) {
+    return {
+      tableId: args[0],
+      variableId: args[1].slice(1, -1),
+    }
+  }
+
+  return EMPTY_STATE
+}
+
+const toExpression = (state: MapState): string => {
+  const { variableId, tableId } = state
+
+  // Set a valid expression if the mapState isn't properly defined
+  if (!variableId || !tableId) {
+    return '0'
+  } else {
+    return `${tableId}[${variableId}]`
+  }
+}
+
+const InputComponent: OperationFieldComponent = ({ operation, index }) => {
+  const { title, expression } = operation
+  const { config, dispatch } = useCheckerContext()
+  const [mapState, setMapState] = useState<MapState>(fromExpression(expression))
+
+  useEffect(() => {
+    const updatedExpr = toExpression(mapState)
+    // TODO: Check args length is 2
+    if (
+      operation.expression !== updatedExpr &&
+      isValidExpression(updatedExpr)
+    ) {
+      dispatch({
+        type: BuilderActionEnum.Update,
+        payload: {
+          currIndex: index,
+          element: { ...operation, expression: updatedExpr },
+          configArrName: ConfigArrayEnum.Operations,
+        },
+      })
+    }
+  }, [mapState, dispatch, index, operation])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...operation, [name]: value },
+        configArrName: ConfigArrayEnum.Operations,
+      },
+    })
+  }
+
+  const handleExprChange = (name: string, value: string) => {
+    setMapState((s) =>
+      update(s, {
+        [name]: { $set: value },
+      })
+    )
+  }
+
+  return (
+    <VStack w="100%" align="stretch" spacing={6}>
+      <HStack w="100%" alignItems="flex-start">
+        <Box fontSize="20px" pt={2}>
+          <BiGitCompare />
+        </Box>
+        <Input
+          name="title"
+          type="text"
+          placeholder="Result description"
+          onChange={handleChange}
+          value={title}
+        />
+      </HStack>
+      <VStack align="stretch" spacing={4}>
+        <HStack>
+          <Box w="100px">
+            <Button variant="ghost">MAP</Button>
+          </Box>
+          <Menu>
+            <MenuButton as={Button} rightIcon={<BiChevronDown />}>
+              {mapState.variableId ? mapState.variableId : 'SELECT INPUT'}
+            </MenuButton>
+            <MenuList>
+              {config.fields.map(({ id, title }, i) => (
+                <MenuItem
+                  key={i}
+                  onClick={() => handleExprChange('variableId', id)}
+                >
+                  <HStack spacing={4}>
+                    <Badge
+                      bg="#FB5D64"
+                      color="white"
+                      fontSize="sm"
+                      borderRadius="5px"
+                    >
+                      {id}
+                    </Badge>
+                    <Text isTruncated>{title}</Text>
+                  </HStack>
+                </MenuItem>
+              ))}
+              {config.operations.map(({ id, title }, i) => (
+                <MenuItem
+                  key={i}
+                  onClick={() => handleExprChange('variableId', id)}
+                >
+                  <HStack spacing={4}>
+                    <Badge
+                      bg="#46DBC9"
+                      color="white"
+                      fontSize="sm"
+                      borderRadius="5px"
+                    >
+                      {id}
+                    </Badge>
+                    <Text isTruncated>{title}</Text>
+                  </HStack>
+                </MenuItem>
+              ))}
+            </MenuList>
+          </Menu>
+        </HStack>
+        <HStack>
+          <Box w="100px">
+            <Button variant="ghost">TO</Button>
+          </Box>
+          <Menu>
+            <MenuButton as={Button} rightIcon={<BiChevronDown />}>
+              {mapState.tableId ? mapState.tableId : 'SELECT MAP TABLE'}
+            </MenuButton>
+            <MenuList>
+              {config.constants.map(({ id, title }, i) => (
+                <MenuItem
+                  key={i}
+                  onClick={() => handleExprChange('tableId', id)}
+                >
+                  <HStack spacing={4}>
+                    <Badge
+                      bg="#1b3c87"
+                      color="white"
+                      fontSize="sm"
+                      borderRadius="5px"
+                    >
+                      {id}
+                    </Badge>
+                    <Text isTruncated>{title}</Text>
+                  </HStack>
+                </MenuItem>
+              ))}
+            </MenuList>
+          </Menu>
+        </HStack>
+      </VStack>
+    </VStack>
+  )
+}
+
+const PreviewComponent: OperationFieldComponent = ({ operation }) => {
+  const { title, expression } = operation
+  return (
+    <VStack align="stretch" w="100%" spacing={4}>
+      <HStack>
+        <BiGitCompare fontSize="20px" />
+        <Text>{title}</Text>
+      </HStack>
+      <Text fontFamily="mono">{expression}</Text>
+    </VStack>
+  )
+}
+
+export const MapResult = createBuilderField(InputComponent, PreviewComponent)

--- a/src/client/components/builder/logic/index.ts
+++ b/src/client/components/builder/logic/index.ts
@@ -1,2 +1,3 @@
 export { CalculatedResult } from './CalculatedResult'
 export { ConditionalResult } from './ConditionalResult'
+export { MapResult } from './MapResult'

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -45,7 +45,7 @@ export interface Operation {
   show: boolean
 }
 
-export type OperationType = 'ARITHMETIC' | 'IFELSE' | 'SWITCH'
+export type OperationType = 'ARITHMETIC' | 'IFELSE' | 'SWITCH' | 'MAP'
 
 export interface TableElem {
   key: string


### PR DESCRIPTION
### Overview

This PR adds the MapResult component to the Logic Tab.

**Active/focused**

<img width="906" alt="Screenshot 2021-02-24 at 7 28 05 PM" src="https://user-images.githubusercontent.com/19917616/108994198-73a1e200-76d6-11eb-8f68-ee945abc0812.png">

**Active/focused with active selector**

<img width="852" alt="Screenshot 2021-02-24 at 7 29 37 PM" src="https://user-images.githubusercontent.com/19917616/108994386-b06dd900-76d6-11eb-8e36-c9d790f74c0a.png">

**Inactive/unfocused**

<img width="831" alt="Screenshot 2021-02-24 at 7 28 10 PM" src="https://user-images.githubusercontent.com/19917616/108994208-77356900-76d6-11eb-8253-20cf4f9ad4f5.png">
