### PR TITLE
fix: lookup option by value instead of index for radio field

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -70,7 +70,11 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
           return (parsedInputs[id] = Number(inputs[id]))
         }
         case 'RADIO': {
-          return (parsedInputs[id] = options[Number(inputs[id])].label)
+          const selected = Number(inputs[id])
+          const option = options.find(({ value }) => value === selected)
+          if (!option)
+            throw new Error(`Unable to find option with value ${selected}`)
+          return (parsedInputs[id] = option.label)
         }
         case 'CHECKBOX': {
           const checkboxValues = Object.values(inputs[id]).map(


### PR DESCRIPTION
## Problem

Current Radio field implementation assumes that the `value` is equals to the index in the `options` array. However, this might not be true if the length of the `options` array changes. 

To reproduce the error:
1. Create a Radio field in the Question Tab
2. Delete the first option
3. Attempt to submit form in the Preview tab
4. An error with the message `Cannot read property 'label' of undefined` should be logged in the console

## Solution

**Bug Fixes**:

- Look up the corresponding option based on `value` when mapping user input to value for Radio fields.
