### PR TITLE
feat: add /ping endpoint for uptime check

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -9,6 +9,11 @@ export default (options: {
   const { checker, auth } = options
   const api = express.Router()
 
+  // Heartbeat check
+  api.get('/ping', (req, res) => {
+    res.status(200).json({ message: 'pong' })
+  })
+
   // Authentication and implicit account creation
   api.post('/auth', auth.sendOTP)
   api.post('/auth/verify', auth.verifyOTP)


### PR DESCRIPTION
This PR adds a GET `/ping` endpoint that we can use to check for uptime.