### PR TITLE
fix(auth): change user localStorage to User | null

### DIFF
--- a/src/client/contexts/AuthContext.tsx
+++ b/src/client/contexts/AuthContext.tsx
@@ -11,7 +11,7 @@ import { AuthService } from '../services'
 
 interface AuthContextProps {
   logout: () => void
-  user: User | undefined
+  user: User | null
   verifyOtp: UseMutationResult<
     void,
     { message: string },
@@ -29,7 +29,7 @@ export const useAuth = (): AuthContextProps => {
 
 export const AuthProvider: FC = ({ children }) => {
   const history = useHistory()
-  const [user, setUser] = useLocalStorage<User | undefined>('user', undefined)
+  const [user, setUser] = useLocalStorage<User | null>('user', null)
   const whoami = () =>
     ApiClient.get<User | null>('/auth/whoami').then((user) => {
       if (user.data) {
@@ -47,7 +47,7 @@ export const AuthProvider: FC = ({ children }) => {
 
   const logout = async () => {
     await ApiClient.post('/auth/logout')
-    setUser(undefined)
+    setUser(null)
   }
 
   const auth = {


### PR DESCRIPTION
## Problem

`useLocalStorage()` uses `JSON.parse()` to retrieve previously
stringified values from localStorage. This is problematic as
`JSON.stringify()` serializes `undefined` to the string "undefined",
which it is then unable to parse, throwing a spurious warning

## Solution

To mitigate this, change the type of `[user, setUser]` to be
`User | null`, so that we are forced to avoid `undefined`. This also
better lines up with what is returned by `/auth/whoami` in the backend.
