### PR TITLE
fix: csp only report violations default to false

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -101,7 +101,7 @@ const config = convict({
     doc: 'Only report CSP violations, do not enforce.',
     env: 'CSP_ONLY_REPORT_VIOLATIONS',
     format: 'Boolean',
-    default: true,
+    default: false,
   },
   sentryDns: {
     doc:


### PR DESCRIPTION
By default, we want CSP violations to be stopped. Hence change in default `convict` value.