### PR TITLE
chore: express time left for otp in minutes

### DIFF
--- a/src/server/auth/AuthService.ts
+++ b/src/server/auth/AuthService.ts
@@ -47,9 +47,10 @@ export class AuthService {
       throw new Error('Invalid email')
     }
     const otp = this.totp.generate(this.secretFrom(email))
-    const html = `Your OTP is <b>${otp}</b>. It will expire in ${
-      this.totp.options.step || NaN
-    } seconds.
+    const timeLeft = this.totp.options.step
+      ? Math.floor(this.totp.options.step / 60) // Round down to minutes
+      : NaN
+    const html = `Your OTP is <b>${otp}</b>. It will expire in ${timeLeft} minutes.
     Please use this to login to your account.
     <p>If your OTP does not work, please request for a new one.</p>
     <p>This login attempt was made from the IP: ${ip}. If you did not attempt to log in, you may choose to ignore this email or investigate this IP address further.</p>`

--- a/src/server/auth/__test__/AuthService.spec.ts
+++ b/src/server/auth/__test__/AuthService.spec.ts
@@ -55,7 +55,9 @@ describe('AuthService', () => {
       expect(mailer.sendMail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: email,
-          html: expect.stringContaining(totp.options.step + ' seconds'),
+          html: expect.stringContaining(
+            Math.floor(totp.options.step / 60) + ' minutes'
+          ),
         })
       )
     })


### PR DESCRIPTION
## Problem

Users prefer seeing time left for their OTP in minutes.

## Solution

**Improvements**:
- Format time left for OTP as minutes (rounded down to nearest minute)

## Tests
- Login and check that email states OTP in minutes