### PR TITLE
fix: generate new uuid when duplicating checker

### DIFF
--- a/src/client/components/dashboard/CreateNewModal.tsx
+++ b/src/client/components/dashboard/CreateNewModal.tsx
@@ -37,7 +37,6 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({
   checker,
 }) => {
   const initial = {
-    id: uuidv4(), // Set id to be a random uuid string
     title: '',
     description: '',
     fields: [],
@@ -88,7 +87,7 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({
     createChecker.mutate({
       ...(checker || initial),
       ...data,
-      id: uuidv4(),
+      id: uuidv4(), // Set id to be a random uuid string
     })
   }
 

--- a/src/client/components/dashboard/CreateNewModal.tsx
+++ b/src/client/components/dashboard/CreateNewModal.tsx
@@ -47,8 +47,17 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({
   }
 
   const toast = useToast({ position: 'bottom-right', variant: 'solid' })
-  const methods = useForm({ mode: 'onBlur' })
-  const { register, handleSubmit, formState } = methods
+  const { register, handleSubmit, formState } = useForm({
+    mode: 'onBlur',
+    ...(checker
+      ? {
+          defaultValues: {
+            title: `Copy of ${checker.title}`,
+            description: checker.description,
+          },
+        }
+      : {}),
+  })
   const { isValid, errors } = formState
 
   const queryClient = useQueryClient()
@@ -77,7 +86,7 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({
     description: string
   }) => {
     createChecker.mutate({
-      ...(checker || initial),
+      ...(checker ? { ...checker, id: uuidv4() } : initial),
       ...data,
     })
   }
@@ -87,28 +96,24 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
-          {checker ? `Copy ${checker.id}` : 'Create new checker'}
+          {checker ? `Duplicate ${checker.title}` : 'Create new checker'}
         </ModalHeader>
         <ModalCloseButton />
         <form onSubmit={handleSubmit(onSubmit)}>
           <ModalBody>
             <VStack spacing={4}>
-              {!checker && (
-                <>
-                  <FormControl isInvalid={errors.title}>
-                    <FormLabel htmlFor="id">Title</FormLabel>
-                    <Input
-                      name="title"
-                      ref={register({ required: 'Title is required' })}
-                    />
-                    <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
-                  </FormControl>
-                  <FormControl isInvalid={errors.description}>
-                    <FormLabel htmlFor="id">Description</FormLabel>
-                    <Textarea name="description" resize="none" ref={register} />
-                  </FormControl>
-                </>
-              )}
+              <FormControl isInvalid={errors.description ? true : false}>
+                <FormLabel htmlFor="id">Title</FormLabel>
+                <Input
+                  name="title"
+                  ref={register({ required: 'Title is required' })}
+                />
+                <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+              </FormControl>
+              <FormControl isInvalid={errors.title ? true : false}>
+                <FormLabel htmlFor="id">Description</FormLabel>
+                <Textarea name="description" resize="none" ref={register} />
+              </FormControl>
             </VStack>
           </ModalBody>
           <ModalFooter>

--- a/src/client/components/dashboard/CreateNewModal.tsx
+++ b/src/client/components/dashboard/CreateNewModal.tsx
@@ -86,8 +86,9 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({
     description: string
   }) => {
     createChecker.mutate({
-      ...(checker ? { ...checker, id: uuidv4() } : initial),
+      ...(checker || initial),
       ...data,
+      id: uuidv4(),
     })
   }
 


### PR DESCRIPTION
## Problem

Closes #245 

## Solution

_How did you solve the problem?_

**Improvements**:
- Allow user to modify checker title and description when duplicating checker

**Bug Fixes**:
- Generate a new `uuid` when duplicating checker

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/111743180-43f48d00-88c4-11eb-831e-509c1208f682.png)

## Tests
- Create a checker with title and description 
- Click duplicate and ensure that the form is pre-populated with values for title and description based on the original checker
- Confirm duplication and checker should be successfully created