### PR TITLE
fix: use ascii quotation marks

### DIFF
--- a/src/client/components/builder/Navbar.tsx
+++ b/src/client/components/builder/Navbar.tsx
@@ -208,7 +208,7 @@ export const Navbar: FC = () => {
                 name="iframe"
                 value={`<iframe src="${linkTo(
                   checker
-                )}" style=“width:100%;height:500px”></iframe>`}
+                )}" style="width:100%;height:500px"></iframe>`}
               >
                 <BiCode size="1rem" />
                 <Text>Embed this checker on your site</Text>

--- a/src/client/hooks/use-local-storage.ts
+++ b/src/client/hooks/use-local-storage.ts
@@ -16,7 +16,7 @@ function useLocalStorage<T>(
       const item = window.localStorage.getItem(key)
       return item ? JSON.parse(item) : initialValue
     } catch (error) {
-      console.warn(`Error reading localStorage key “${key}”:`, error)
+      console.warn(`Error reading localStorage key "${key}":`, error)
       return initialValue
     }
   }
@@ -29,7 +29,7 @@ function useLocalStorage<T>(
     // Prevent build error "window is undefined" but keep keep working
     if (typeof window == 'undefined') {
       console.warn(
-        `Tried setting localStorage key “${key}” even though environment is not a client`
+        `Tried setting localStorage key "${key}" even though environment is not a client`
       )
     }
     try {
@@ -42,7 +42,7 @@ function useLocalStorage<T>(
       // We dispatch a custom event so every useLocalStorage hook are notified
       window.dispatchEvent(new Event('local-storage'))
     } catch (error) {
-      console.warn(`Error setting localStorage key “${key}”:`, error)
+      console.warn(`Error setting localStorage key "${key}":`, error)
     }
   }
   useEffect(() => {


### PR DESCRIPTION
Closes #241 
- non-ascii quotation marks cause css in sample iframe tag in the embed modal to fail
- removed other instances of non-ascii quotes

Possible extension: add ESLint plugin: https://github.com/personaljs/eslint-plugin-ascii though i think this problem isn't significant enough to warrant the extra dependency
