### PR TITLE
feat(builder): create DropdownField

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -13,7 +13,13 @@ import {
 } from '@chakra-ui/react'
 import { useForm, FormProvider } from 'react-hook-form'
 
-import { CheckboxField, RadioField, NumericField, DateField } from './fields'
+import {
+  CheckboxField,
+  RadioField,
+  DropdownField,
+  NumericField,
+  DateField,
+} from './fields'
 import { LineDisplay } from './displays'
 import * as checker from './../../types/checker'
 import { evaluate } from './../core/evaluator'
@@ -44,6 +50,8 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
         return <CheckboxField key={i} {...field} />
       case 'RADIO':
         return <RadioField key={i} {...field} />
+      case 'DROPDOWN':
+        return <DropdownField key={i} {...field} />
       case 'DATE':
         return <DateField key={i} {...field} />
     }
@@ -86,6 +94,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
         case 'NUMERIC': {
           return (parsedInputs[id] = Number(inputs[id]))
         }
+        case 'DROPDOWN':
         case 'RADIO': {
           const selected = Number(inputs[id])
           const option = options.find(({ value }) => value === selected)

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -140,9 +140,10 @@ export const createBuilderField = (
 
   const handleDuplicate = () => {
     if (isFieldData(data)) {
+      const [prefix] = data.id.match(/^[^\d]+/) || []
       const updatedData = {
         ...data,
-        id: `${data.id[0]}${nextUniqueId}`,
+        id: `${prefix}${nextUniqueId}`,
       }
       dispatch({
         type: BuilderActionEnum.Add,

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -81,7 +81,7 @@ export const QuestionsTab: FC = () => {
   useEffect(() => {
     let highestIndex = 0
     config.fields.forEach((field) => {
-      const fieldIndex = parseInt(field.id.slice(1))
+      const fieldIndex = parseInt((field.id.match(/\d+/) || [])[0])
       highestIndex = Math.max(highestIndex, fieldIndex)
     })
     setNextUniqueId(highestIndex + 1)

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -8,6 +8,7 @@ import {
   BiDownArrowAlt,
   BiCalendar,
 } from 'react-icons/bi'
+import { IoIosArrowDropdown } from 'react-icons/io'
 import { VStack } from '@chakra-ui/react'
 
 import * as checker from '../../../types/checker'
@@ -18,6 +19,7 @@ import {
   CheckboxField,
   TitleField,
   DateField,
+  DropdownField,
 } from '../builder/questions'
 
 import { useCheckerContext } from '../../contexts'
@@ -37,6 +39,14 @@ const generateDefaultNumericField = (id: number): checker.Field => ({
 const generateDefaultRadioField = (id: number): checker.Field => ({
   id: `R${id}`,
   type: 'RADIO',
+  title: 'Insert question title',
+  description: '',
+  options: [{ label: 'Option 1', value: 0 }],
+})
+
+const generateDefaultDropdownField = (id: number): checker.Field => ({
+  id: `DL${id}`,
+  type: 'DROPDOWN',
   title: 'Insert question title',
   description: '',
   options: [{ label: 'Option 1', value: 0 }],
@@ -106,6 +116,22 @@ export const QuestionsTab: FC = () => {
               type: BuilderActionEnum.Add,
               payload: {
                 element: generateDefaultRadioField(nextUniqueId),
+                configArrName: ConfigArrayEnum.Fields,
+                newIndex: activeIndex + 1,
+              },
+            })
+            setActiveIndex(activeIndex + 1)
+            setNextUniqueId(nextUniqueId + 1)
+          },
+        },
+        {
+          label: 'Dropdown List',
+          icon: <IoIosArrowDropdown />,
+          onClick: () => {
+            dispatch({
+              type: BuilderActionEnum.Add,
+              payload: {
+                element: generateDefaultDropdownField(nextUniqueId),
                 configArrName: ConfigArrayEnum.Fields,
                 newIndex: activeIndex + 1,
               },
@@ -208,6 +234,8 @@ export const QuestionsTab: FC = () => {
     switch (field.type) {
       case 'RADIO':
         return <RadioField {...commonProps} />
+      case 'DROPDOWN':
+        return <DropdownField {...commonProps} />
       case 'CHECKBOX':
         return <CheckboxField {...commonProps} />
       case 'NUMERIC':

--- a/src/client/components/builder/questions/DropdownField.tsx
+++ b/src/client/components/builder/questions/DropdownField.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   Input,
   Radio,
-  RadioGroup,
+  Select,
 } from '@chakra-ui/react'
 
 import * as checker from '../../../../types/checker'
@@ -149,15 +149,13 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
         </HStack>
         {description && <Text color="#718096">{description}</Text>}
       </VStack>
-      <RadioGroup>
-        <VStack alignItems="left" spacing={2}>
-          {options.map(({ value, label }, i) => (
-            <Radio key={i} value={value} isChecked={false}>
-              {label}
-            </Radio>
-          ))}
-        </VStack>
-      </RadioGroup>
+      <Select>
+        {options.map(({ value, label }, i) => (
+          <option key={i} value={value}>
+            {label}
+          </option>
+        ))}
+      </Select>
     </VStack>
   )
 }

--- a/src/client/components/builder/questions/DropdownField.tsx
+++ b/src/client/components/builder/questions/DropdownField.tsx
@@ -1,0 +1,168 @@
+import React from 'react'
+import { BiListUl, BiX } from 'react-icons/bi'
+import {
+  Button,
+  IconButton,
+  Box,
+  HStack,
+  VStack,
+  Text,
+  Input,
+  Radio,
+  RadioGroup,
+} from '@chakra-ui/react'
+
+import * as checker from '../../../../types/checker'
+import { useCheckerContext } from '../../../contexts'
+import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
+import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+
+const InputComponent: QuestionFieldComponent = ({ field, index }) => {
+  const { title, description } = field
+  const { dispatch } = useCheckerContext()
+
+  const updateTitleOrDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, [name]: value },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
+  }
+
+  const deleteOption = (option: checker.FieldOption, i: number) => {
+    field.options.splice(i, 1)
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, options: field.options },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
+  }
+
+  const updateOption = (
+    option: checker.FieldOption,
+    update: Partial<checker.FieldOption>,
+    i: number
+  ) => {
+    const updatedOption = { ...option, ...update }
+    field.options.splice(i, 1, updatedOption)
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, options: field.options },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
+  }
+
+  const addOption = () => {
+    const newOptionLabel = `Option ${field.options.length + 1}`
+    // newValue is an increment of the last option's value to ensure that values are unique
+    const newValue = field.options[field.options.length - 1].value + 1
+    const newOption = { label: newOptionLabel, value: newValue }
+    field.options.push(newOption)
+    dispatch({
+      type: BuilderActionEnum.Update,
+      payload: {
+        currIndex: index,
+        element: { ...field, options: field.options },
+        configArrName: ConfigArrayEnum.Fields,
+      },
+    })
+  }
+
+  const renderOption = (option: checker.FieldOption, i: number) => {
+    return (
+      <HStack key={i}>
+        <Radio isChecked={false} />
+        <Input
+          type="text"
+          value={option.label}
+          onChange={(e) => {
+            updateOption(option, { label: e.target.value }, i)
+          }}
+        />
+        <IconButton
+          aria-label="Delete option"
+          fontSize="20px"
+          icon={<BiX />}
+          disabled={field.options.length <= 1}
+          onClick={() => deleteOption(option, i)}
+        />
+      </HStack>
+    )
+  }
+
+  return (
+    <HStack w="100%" alignItems="flex-start">
+      <Box fontSize="20px" pt={2}>
+        <BiListUl />
+      </Box>
+      <VStack align="stretch" w="90%" spacing={6}>
+        <VStack align="stretch" spacing={2}>
+          <Input
+            type="text"
+            name="title"
+            placeholder="Question"
+            onChange={updateTitleOrDescription}
+            value={title}
+          />
+          <Input
+            type="text"
+            name="description"
+            placeholder="Description"
+            onChange={updateTitleOrDescription}
+            value={description}
+          />
+        </VStack>
+        <VStack spacing={4} alignItems="left" w="50%">
+          {field.options.map(renderOption)}
+          <HStack h={10}>
+            <Radio isChecked={false} />
+            <Box pl={2}>
+              <Button variant="link" onClick={addOption}>
+                Add new option
+              </Button>
+            </Box>
+          </HStack>
+        </VStack>
+      </VStack>
+    </HStack>
+  )
+}
+
+const PreviewComponent: QuestionFieldComponent = ({ field }) => {
+  const { title, description, options } = field
+  return (
+    <VStack align="stretch" w="100%" spacing={6}>
+      <VStack align="stretch">
+        <HStack>
+          <BiListUl fontSize="20px" />
+          <Text>{title}</Text>
+        </HStack>
+        {description && <Text color="#718096">{description}</Text>}
+      </VStack>
+      <RadioGroup>
+        <VStack alignItems="left" spacing={2}>
+          {options.map(({ value, label }, i) => (
+            <Radio key={i} value={value} isChecked={false}>
+              {label}
+            </Radio>
+          ))}
+        </VStack>
+      </RadioGroup>
+    </VStack>
+  )
+}
+
+export const DropdownField = createBuilderField(
+  InputComponent,
+  PreviewComponent
+)

--- a/src/client/components/builder/questions/DropdownField.tsx
+++ b/src/client/components/builder/questions/DropdownField.tsx
@@ -1,18 +1,15 @@
 import React from 'react'
-import { BiListUl, BiX } from 'react-icons/bi'
+import { BiListUl } from 'react-icons/bi'
 import {
-  Button,
-  IconButton,
   Box,
   HStack,
   VStack,
   Text,
   Input,
-  Radio,
   Select,
+  Textarea,
 } from '@chakra-ui/react'
 
-import * as checker from '../../../../types/checker'
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
@@ -33,71 +30,18 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
     })
   }
 
-  const deleteOption = (option: checker.FieldOption, i: number) => {
-    field.options.splice(i, 1)
+  const changeOptions = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value
+    const options = text.split('\n').map((label, value) => ({ label, value }))
+    field.options = options
     dispatch({
       type: BuilderActionEnum.Update,
       payload: {
         currIndex: index,
-        element: { ...field, options: field.options },
+        element: { ...field, options },
         configArrName: ConfigArrayEnum.Fields,
       },
     })
-  }
-
-  const updateOption = (
-    option: checker.FieldOption,
-    update: Partial<checker.FieldOption>,
-    i: number
-  ) => {
-    const updatedOption = { ...option, ...update }
-    field.options.splice(i, 1, updatedOption)
-    dispatch({
-      type: BuilderActionEnum.Update,
-      payload: {
-        currIndex: index,
-        element: { ...field, options: field.options },
-        configArrName: ConfigArrayEnum.Fields,
-      },
-    })
-  }
-
-  const addOption = () => {
-    const newOptionLabel = `Option ${field.options.length + 1}`
-    // newValue is an increment of the last option's value to ensure that values are unique
-    const newValue = field.options[field.options.length - 1].value + 1
-    const newOption = { label: newOptionLabel, value: newValue }
-    field.options.push(newOption)
-    dispatch({
-      type: BuilderActionEnum.Update,
-      payload: {
-        currIndex: index,
-        element: { ...field, options: field.options },
-        configArrName: ConfigArrayEnum.Fields,
-      },
-    })
-  }
-
-  const renderOption = (option: checker.FieldOption, i: number) => {
-    return (
-      <HStack key={i}>
-        <Radio isChecked={false} />
-        <Input
-          type="text"
-          value={option.label}
-          onChange={(e) => {
-            updateOption(option, { label: e.target.value }, i)
-          }}
-        />
-        <IconButton
-          aria-label="Delete option"
-          fontSize="20px"
-          icon={<BiX />}
-          disabled={field.options.length <= 1}
-          onClick={() => deleteOption(option, i)}
-        />
-      </HStack>
-    )
   }
 
   return (
@@ -123,15 +67,11 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
           />
         </VStack>
         <VStack spacing={4} alignItems="left" w="50%">
-          {field.options.map(renderOption)}
-          <HStack h={10}>
-            <Radio isChecked={false} />
-            <Box pl={2}>
-              <Button variant="link" onClick={addOption}>
-                Add new option
-              </Button>
-            </Box>
-          </HStack>
+          <Textarea
+            value={field.options.map((o) => o.label).join('\n')}
+            onChange={changeOptions}
+            placeholder="Enter each option on a new line"
+          />
         </VStack>
       </VStack>
     </HStack>

--- a/src/client/components/builder/questions/DropdownField.tsx
+++ b/src/client/components/builder/questions/DropdownField.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Select,
   Textarea,
+  useStyles,
 } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
@@ -80,6 +81,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
 
 const PreviewComponent: QuestionFieldComponent = ({ field }) => {
   const { title, description, options } = field
+  const styles = useStyles()
   return (
     <VStack align="stretch" w="100%" spacing={6}>
       <VStack align="stretch">
@@ -89,7 +91,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
         </HStack>
         {description && <Text color="#718096">{description}</Text>}
       </VStack>
-      <Select>
+      <Select isDisabled sx={styles.dummyInput}>
         {options.map(({ value, label }, i) => (
           <option key={i} value={value}>
             {label}

--- a/src/client/components/builder/questions/index.ts
+++ b/src/client/components/builder/questions/index.ts
@@ -1,5 +1,6 @@
 export { TitleField } from './TitleField'
 export { NumericField } from './NumericField'
 export { RadioField } from './RadioField'
+export { DropdownField } from './DropdownField'
 export { CheckboxField } from './CheckboxField'
 export { DateField } from './DateField'

--- a/src/client/components/fields/DropdownField.tsx
+++ b/src/client/components/fields/DropdownField.tsx
@@ -1,0 +1,62 @@
+import React, { FC } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import {
+  useStyles,
+  VStack,
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  FormErrorMessage,
+  Radio as RadioInput,
+  RadioGroup,
+} from '@chakra-ui/react'
+
+import { Field } from '../../../types/checker'
+
+export const DropdownField: FC<Field> = ({
+  id,
+  title,
+  description,
+  options,
+}) => {
+  const styles = useStyles()
+  const { control } = useFormContext()
+
+  return (
+    <Controller
+      name={id}
+      control={control}
+      rules={{ required: true }}
+      defaultValue={`${options[0]?.value}`}
+      render={({ ref, value, onChange }, { invalid }) => (
+        <FormControl isInvalid={invalid}>
+          <FormLabel sx={styles.label} htmlFor={id}>
+            {title}
+          </FormLabel>
+          {description && <FormHelperText mb={4}>{description}</FormHelperText>}
+          <RadioGroup name={id} value={value} onChange={onChange}>
+            <VStack align="stretch" spacing={4}>
+              {options.map(
+                (
+                  { value, label }: { value: number; label: string },
+                  i: number
+                ) => (
+                  <RadioInput
+                    colorScheme="primary"
+                    key={i}
+                    ref={ref}
+                    name={id}
+                    value={`${value}`}
+                  >
+                    {label}
+                  </RadioInput>
+                )
+              )}
+            </VStack>
+          </RadioGroup>
+          <FormErrorMessage>Field is required</FormErrorMessage>
+        </FormControl>
+      )}
+    />
+  )
+}

--- a/src/client/components/fields/DropdownField.tsx
+++ b/src/client/components/fields/DropdownField.tsx
@@ -2,13 +2,11 @@ import React, { FC } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import {
   useStyles,
-  VStack,
   FormControl,
   FormLabel,
   FormHelperText,
   FormErrorMessage,
-  Radio as RadioInput,
-  RadioGroup,
+  Select,
 } from '@chakra-ui/react'
 
 import { Field } from '../../../types/checker'
@@ -34,26 +32,18 @@ export const DropdownField: FC<Field> = ({
             {title}
           </FormLabel>
           {description && <FormHelperText mb={4}>{description}</FormHelperText>}
-          <RadioGroup name={id} value={value} onChange={onChange}>
-            <VStack align="stretch" spacing={4}>
-              {options.map(
-                (
-                  { value, label }: { value: number; label: string },
-                  i: number
-                ) => (
-                  <RadioInput
-                    colorScheme="primary"
-                    key={i}
-                    ref={ref}
-                    name={id}
-                    value={`${value}`}
-                  >
-                    {label}
-                  </RadioInput>
-                )
-              )}
-            </VStack>
-          </RadioGroup>
+          <Select name={id} value={value} onChange={onChange}>
+            {options.map(
+              (
+                { value, label }: { value: number; label: string },
+                i: number
+              ) => (
+                <option key={i} ref={ref} value={`${value}`}>
+                  {label}
+                </option>
+              )
+            )}
+          </Select>
           <FormErrorMessage>Field is required</FormErrorMessage>
         </FormControl>
       )}

--- a/src/client/components/fields/index.ts
+++ b/src/client/components/fields/index.ts
@@ -1,4 +1,5 @@
 export * from './CheckboxField'
 export * from './RadioField'
+export * from './DropdownField'
 export * from './NumericField'
 export * from './DateField'

--- a/src/server/checker/CheckerSchema.ts
+++ b/src/server/checker/CheckerSchema.ts
@@ -8,12 +8,12 @@ const FieldOptionsSchema = Joi.object({
 const FieldSchema = Joi.object({
   id: Joi.string().required(),
   type: Joi.string()
-    .valid('NUMERIC', 'RADIO', 'CHECKBOX', 'SLIDER', 'DATE')
+    .valid('NUMERIC', 'RADIO', 'DROPDOWN', 'CHECKBOX', 'SLIDER', 'DATE')
     .required(),
   title: Joi.string().required(),
   description: Joi.string().allow('').required(),
   options: Joi.when('type', {
-    is: Joi.valid('RADIO', 'CHECKBOX'),
+    is: Joi.valid('RADIO', 'DROPDOWN', 'CHECKBOX'),
     then: Joi.array().items(FieldOptionsSchema).min(1),
     otherwise: Joi.array().length(0),
   }).required(),

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -33,7 +33,13 @@ export interface FieldOption {
   value: number
 }
 
-export type FieldType = 'NUMERIC' | 'RADIO' | 'CHECKBOX' | 'SLIDER' | 'DATE'
+export type FieldType =
+  | 'NUMERIC'
+  | 'RADIO'
+  | 'DROPDOWN'
+  | 'CHECKBOX'
+  | 'SLIDER'
+  | 'DATE'
 
 export interface Display {
   id: string


### PR DESCRIPTION
## Problem

RadioField tends to be unwieldy for situations where more than 5 options are needed

## Solution

Create DropdownField, using textarea as input

- copy RadioField and add relevant entries across the builder and public views
- ditch the radio buttons borrowed from RadioField in favour of chakra's Select control
- use a textarea to accept DropdownField options

## Screenshots
![image](https://user-images.githubusercontent.com/10572368/112119083-fe073400-8bf7-11eb-9f81-02f3410ddc36.png)
![image](https://user-images.githubusercontent.com/10572368/112119665-8ab1f200-8bf8-11eb-9ee9-b865abc0cce0.png)
![image](https://user-images.githubusercontent.com/10572368/112119320-3c045800-8bf8-11eb-83e5-0a9aed851eef.png)
