### PR TITLE
feat: add backend sentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_STAGING }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_STAGING }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_STAGING }} >> $GITHUB_ENV;
-            echo SENTRY_ENVIRONMENT=${{ secrets.SENTRY_ENVIRONMENT_STAGING }} >> $GITHUB_ENV;
             echo APP_HOST=staging.checkfirst.gov.sg >> $GITHUB_ENV;
           elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
             echo LAMBDA_NODE_ENV=production >> $GITHUB_ENV;
@@ -111,7 +110,6 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_PRODUCTION }} >> $GITHUB_ENV;
-            echo SENTRY_ENVIRONMENT=${{ secrets.SENTRY_ENVIRONMENT_PRODUCTION }} >> $GITHUB_ENV;
             echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV
           fi
           echo SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} >> $GITHUB_ENV;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,4 @@ jobs:
           APP_HOST: ${{ env.APP_HOST }}
           FRONTEND_SENTRY_DSN: ${{ secrets.FRONTEND_SENTRY_DSN }}
           BACKEND_SENTRY_DSN: ${{ secrets.BACKEND_SENTRY_DSN }}
+          CSP_REPORT_URI: ${{ secrets.CSP_REPORT_URI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
         env: 
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FRONTEND_SENTRY_DSN: ${{ secrets.FRONTEND_SENTRY_DSN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       - name: serverless deploy
         uses: opengovsg/serverless-github-action@v2.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@ jobs:
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_PRODUCTION }} >> $GITHUB_ENV;
             echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV
           fi
-          echo SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} >> $GITHUB_ENV;
-          echo FRONTEND_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }} >> $GITHUB_ENV;
-          echo BACKEND_SENTRY_DSN=${{ secrets.BACKEND_SENTRY_DSN }} >> $GITHUB_ENV;
       - run: npm run build
+        env: 
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          FRONTEND_SENTRY_DSN: ${{ secrets.FRONTEND_SENTRY_DSN }}
       - name: serverless deploy
         uses: opengovsg/serverless-github-action@v2.1.0
         with:
@@ -135,3 +135,5 @@ jobs:
           OTP_SECRET: ${{ env.OTP_SECRET }}
           OTP_EXPIRY: ${{ secrets.OTP_EXPIRY }}
           APP_HOST: ${{ env.APP_HOST }}
+          FRONTEND_SENTRY_DSN: ${{ secrets.FRONTEND_SENTRY_DSN }}
+          BACKEND_SENTRY_DSN: ${{ secrets.BACKEND_SENTRY_DSN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,6 @@ jobs:
           echo SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} >> $GITHUB_ENV;
           echo FRONTEND_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }} >> $GITHUB_ENV;
           echo BACKEND_SENTRY_DSN=${{ secrets.BACKEND_SENTRY_DSN }} >> $GITHUB_ENV;
-          echo SENTRY_ORG=${{ secrets.SENTRY_ORG }} >> $GITHUB_ENV;
-          echo SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }} >> $GITHUB_ENV;
-          echo SENTRY_URL=${{ secrets.SENTRY_URL }} >> $GITHUB_ENV;
       - run: npm run build
       - name: serverless deploy
         uses: opengovsg/serverless-github-action@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           fi
           echo SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} >> $GITHUB_ENV;
           echo FRONTEND_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }} >> $GITHUB_ENV;
+          echo BACKEND_SENTRY_DSN=${{ secrets.BACKEND_SENTRY_DSN }} >> $GITHUB_ENV;
           echo SENTRY_ORG=${{ secrets.SENTRY_ORG }} >> $GITHUB_ENV;
           echo SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }} >> $GITHUB_ENV;
           echo SENTRY_URL=${{ secrets.SENTRY_URL }} >> $GITHUB_ENV;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2630,6 +2630,29 @@
         "tslib": "^1.9.3"
       }
     },
+    "@sentry/node": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.3.tgz",
+      "integrity": "sha512-MaT8Uj+dOi1FPR4GkRGoQwaqxWKtfz+KpZ2RUT+x6aMqE8nieDFKts0i7O2vALg7LbRFzVsDsvK2GWcunfYkpA==",
+      "requires": {
+        "@sentry/core": "6.2.3",
+        "@sentry/hub": "6.2.3",
+        "@sentry/tracing": "6.2.3",
+        "@sentry/types": "6.2.3",
+        "@sentry/utils": "6.2.3",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
     "@sentry/react": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.2.3.tgz",
@@ -3686,7 +3709,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       },
@@ -3695,7 +3717,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -3703,8 +3724,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -8616,7 +8636,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -8626,7 +8645,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -8634,8 +8652,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -10558,6 +10575,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@chakra-ui/react": "^1.4.1",
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.1.5",
+    "@sentry/node": "^6.2.3",
     "@sentry/react": "^6.2.3",
     "@sentry/tracing": "^6.2.3",
     "ace-builds": "^1.4.12",

--- a/serverless.yml
+++ b/serverless.yml
@@ -44,6 +44,8 @@ functions:
       OTP_SECRET: ${env:OTP_SECRET}
       OTP_EXPIRY: ${env:OTP_EXPIRY}
       FRONTEND_SENTRY_DSN: ${env:FRONTEND_SENTRY_DSN}
+      BACKEND_SENTRY_DSN: ${env:BACKEND_SENTRY_DSN}
+      SENTRY_ENVIRONMENT: ${env:SENTRY_ENVIRONMENT}
     events:
       - http:
           path: api/v1/{proxy+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -45,7 +45,6 @@ functions:
       OTP_EXPIRY: ${env:OTP_EXPIRY}
       FRONTEND_SENTRY_DSN: ${env:FRONTEND_SENTRY_DSN}
       BACKEND_SENTRY_DSN: ${env:BACKEND_SENTRY_DSN}
-      SENTRY_ENVIRONMENT: ${env:SENTRY_ENVIRONMENT}
     events:
       - http:
           path: api/v1/{proxy+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -45,6 +45,7 @@ functions:
       OTP_EXPIRY: ${env:OTP_EXPIRY}
       FRONTEND_SENTRY_DSN: ${env:FRONTEND_SENTRY_DSN}
       BACKEND_SENTRY_DSN: ${env:BACKEND_SENTRY_DSN}
+      CSP_REPORT_URI: ${env:CSP_REPORT_URI}
     events:
       - http:
           path: api/v1/{proxy+}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -23,6 +23,7 @@ const queryClient = new QueryClient({
 
 Sentry.init({
   dsn: process.env.FRONTEND_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
   integrations: [
     new Integrations.BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),

--- a/src/server/bootstrap/index.ts
+++ b/src/server/bootstrap/index.ts
@@ -1,7 +1,9 @@
-import express, { Express } from 'express'
+import express, { Express, Request, Response, NextFunction } from 'express'
 import session from 'express-session'
 import SequelizeStoreFactory from 'connect-session-sequelize'
 import bodyParser from 'body-parser'
+import * as Sentry from '@sentry/node'
+import * as Tracing from '@sentry/tracing'
 
 import minimatch from 'minimatch'
 import { totp as totpFactory } from 'otplib'
@@ -72,19 +74,54 @@ export async function bootstrap(): Promise<Express> {
     name: 'checkfirst',
   })
 
+  const sentrySessionMiddleware = (
+    req: Request,
+    _res: Response,
+    next: NextFunction
+  ): void => {
+    if (req.session?.user) {
+      const { email, id } = req.session.user
+      Sentry.setUser({
+        id: id.toString(),
+        email: email,
+      })
+    }
+    next()
+  }
+
   const app = express()
+
+  Sentry.init({
+    dsn: process.env.BACKEND_SENTRY_DSN,
+    // automatically picks up environment from SENTRY_ENVIRONMENT
+    integrations: [
+      // enable HTTP calls tracing
+      new Sentry.Integrations.Http({ tracing: true }),
+      // enable Express.js middleware tracing
+      new Tracing.Integrations.Express({ app }),
+    ],
+    tracesSampleRate: 1.0,
+  })
 
   if (secure) {
     app.set('trust proxy', 1)
   }
+  app.use(Sentry.Handlers.requestHandler())
+  app.use(Sentry.Handlers.tracingHandler())
 
   app.use(morgan)
   app.use(helmet)
 
-  const apiMiddleware = [sessionMiddleware, bodyParser.json()]
+  const apiMiddleware = [
+    sessionMiddleware,
+    bodyParser.json(),
+    sentrySessionMiddleware, // TODO: debug why user info isn't sent
+  ]
   app.use('/api/v1', apiMiddleware, api({ checker, auth }))
 
   addStaticRoutes(app)
+
+  app.use(Sentry.Handlers.errorHandler())
 
   await sequelize.authenticate()
   return app

--- a/src/server/bootstrap/index.ts
+++ b/src/server/bootstrap/index.ts
@@ -93,7 +93,6 @@ export async function bootstrap(): Promise<Express> {
 
   Sentry.init({
     dsn: config.get('backendSentryDsn'),
-    // automatically picks up environment from SENTRY_ENVIRONMENT
     integrations: [
       // enable HTTP calls tracing
       new Sentry.Integrations.Http({ tracing: true }),

--- a/src/server/bootstrap/index.ts
+++ b/src/server/bootstrap/index.ts
@@ -92,7 +92,7 @@ export async function bootstrap(): Promise<Express> {
   const app = express()
 
   Sentry.init({
-    dsn: process.env.BACKEND_SENTRY_DSN,
+    dsn: config.get('backendSentryDsn'),
     // automatically picks up environment from SENTRY_ENVIRONMENT
     integrations: [
       // enable HTTP calls tracing
@@ -101,6 +101,7 @@ export async function bootstrap(): Promise<Express> {
       new Tracing.Integrations.Express({ app }),
     ],
     tracesSampleRate: 1.0,
+    environment: config.get('nodeEnv'),
   })
 
   if (secure) {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -109,6 +109,13 @@ const config = convict({
     format: 'Boolean',
     default: false,
   },
+  backendSentryDsn: {
+    doc:
+      'The Sentry DSN used for bug and error tracking. e.g. `https://12345@sentry.io/12345`',
+    env: 'BACKEND_SENTRY_DSN',
+    format: '*',
+    default: '',
+  },
   frontendSentryDsn: {
     doc:
       'The Sentry DSN used for bug and error tracking. e.g. `https://12345@sentry.io/12345`',

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -118,7 +118,7 @@ const config = convict({
   },
   frontendSentryDsn: {
     doc:
-      'The Sentry DSN used for bug and error tracking. e.g. `https://12345@sentry.io/12345`',
+      'The Sentry DSN used for bug and error tracking. e.g. `https://12345@sentry.io/12345`. Used by CSP.',
     env: 'FRONTEND_SENTRY_DSN',
     format: '*',
     default: '',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = () => {
         ignoreFile: '.gitignore',
         ignore: ['node_modules', 'webpack.config.js'],
         deploy: {
-          env: process.env.SENTRY_ENVIRONMENT,
+          env: process.env.LAMBDA_NODE_ENV,
         },
       })
     )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ const requiredSentryEnvVar = [
   process.env.FRONTEND_SENTRY_DSN,
   process.env.SENTRY_ORG,
   process.env.SENTRY_PROJECT,
-  process.env.SENTRY_URL,
 ]
 
 module.exports = () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,7 @@ module.exports = () => {
         'process.env.FRONTEND_SENTRY_DSN': JSON.stringify(
           process.env.FRONTEND_SENTRY_DSN
         ),
+        'process.env.NODE_ENV': JSON.stringify(process.env.LAMBDA_NODE_ENV),
       }),
     ],
   }


### PR DESCRIPTION
- use sentry express integration
- set user from session user

**New environment variables**:

- `BACKEND_SENTRY_DSN`
- `CSP_REPORT_URI`: wasn't previously linked up in `serverless.yml` and `ci.yml` for the CSP PR

**New dependencies**:

- `@sentry/node`
- `@sentry/tracing`

### Testing

Add a route that throws an error: https://docs.sentry.io/platforms/node/guides/express/. Then ping that endpoint by navigating to it on browser eg. `localhost:3000` or using postman.
```
app.get("/debug-sentry", function mainHandler(req, res) {
  throw new Error("My first Sentry error!");
});
```

NOTE: an error thrown in a async function won't be caught by sentry error handler

TODO: 
- fix `sentrySessionMiddleware` to add user info when error occurs
- investigate further as to why async functions are not caught by sentry