### PR TITLE
fix(builder): do not fetch checker on window refocus

### DIFF
--- a/src/client/contexts/CheckerContext.tsx
+++ b/src/client/contexts/CheckerContext.tsx
@@ -148,8 +148,10 @@ export const CheckerProvider: FC = ({ children }) => {
   }
 
   // Initial query for checker data
-  const { isSuccess, data } = useQuery(['builder', id], () =>
-    CheckerService.getChecker(id)
+  const { isSuccess, data } = useQuery(
+    ['builder', id],
+    () => CheckerService.getChecker(id),
+    { refetchOnWindowFocus: false }
   )
   useEffect(() => {
     if (data) {


### PR DESCRIPTION
## Problem
By default, react-query fetches the last saved state of the checker
when the user refocuses the window (eg, by clicking on another browser
tab then returning to CheckFirst). This decimates any unsaved changes
that the user might have had.

## Solution
Fix this by explicitly specifying no fetching on window refocus
