### PR TITLE
feat(otp): include app host when sending OTP mail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_STAGING }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_STAGING }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_STAGING }} >> $GITHUB_ENV;
+            echo APP_HOST=staging.checkfirst.gov.sg >> $GITHUB_ENV;
           elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
             echo LAMBDA_NODE_ENV=production >> $GITHUB_ENV;
             echo VPC_SUBNET_A=${{ secrets.VPC_SUBNET_A_PRODUCTION }} >> $GITHUB_ENV;
@@ -109,6 +110,7 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_PRODUCTION }} >> $GITHUB_ENV;
+            echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV
           fi
       - run: npm run build
       - name: serverless deploy
@@ -129,3 +131,4 @@ jobs:
           SESSION_SECRET: ${{ env.SESSION_SECRET }}
           OTP_SECRET: ${{ env.OTP_SECRET }}
           OTP_EXPIRY: ${{ secrets.OTP_EXPIRY }}
+          APP_HOST: ${{ env.APP_HOST }}

--- a/src/server/auth/AuthService.ts
+++ b/src/server/auth/AuthService.ts
@@ -8,6 +8,7 @@ import { ModelOf } from '../models'
 
 export class AuthService {
   private secret: string
+  private appHost: string
   private emailValidator: IMinimatch
   private totp: Pick<typeof totpGlobal, 'generate' | 'verify' | 'options'>
   private mailer: Pick<Transporter, 'sendMail'>
@@ -16,6 +17,7 @@ export class AuthService {
 
   constructor({
     secret,
+    appHost,
     emailValidator,
     totp,
     mailer,
@@ -23,6 +25,7 @@ export class AuthService {
     logger,
   }: {
     secret: string
+    appHost: string
     emailValidator: IMinimatch
     totp: Pick<typeof totpGlobal, 'generate' | 'verify' | 'options'>
     mailer: Pick<Transporter, 'sendMail'>
@@ -30,6 +33,7 @@ export class AuthService {
     logger?: winston.Logger
   }) {
     this.secret = secret
+    this.appHost = appHost
     this.emailValidator = emailValidator
     this.totp = totp
     this.mailer = mailer
@@ -52,7 +56,7 @@ export class AuthService {
       : NaN
     const html = `Your OTP is <b>${otp}</b>. It will expire in ${timeLeft} minutes.
     Please use this to login to your account.
-    <p>If your OTP does not work, please request for a new one.</p>
+    <p>If your OTP does not work, please request for a new one from ${this.appHost}.</p>
     <p>This login attempt was made from the IP: ${ip}. If you did not attempt to log in, you may choose to ignore this email or investigate this IP address further.</p>`
 
     const mail: SendMailOptions = {

--- a/src/server/auth/__test__/AuthService.spec.ts
+++ b/src/server/auth/__test__/AuthService.spec.ts
@@ -12,6 +12,7 @@ describe('AuthService', () => {
     options: { step: 60 },
   }
   const secret = 'toomanysecrets'
+  const appHost = 'checkfirst.gov.sg'
   const emailValidator = new minimatch.Minimatch('*.gov.sg')
   const mailer = { sendMail: jest.fn() }
   const User = init(sequelize, { emailValidator })
@@ -20,6 +21,7 @@ describe('AuthService', () => {
 
   const service = new AuthService({
     secret,
+    appHost,
     emailValidator,
     totp,
     mailer,

--- a/src/server/bootstrap/index.ts
+++ b/src/server/bootstrap/index.ts
@@ -48,6 +48,7 @@ export async function bootstrap(): Promise<Express> {
     logger,
     service: new AuthService({
       secret: config.get('otpSecret'),
+      appHost: config.get('appHost'),
       emailValidator,
       totp,
       mailer,

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -46,6 +46,12 @@ const config = convict({
     format: 'int',
     default: 14400000, // 4 hours
   },
+  appHost: {
+    doc: 'The fully-qualified domain name of the application',
+    env: 'APP_HOST',
+    format: '*',
+    default: 'checkfirst.gov.sg',
+  },
   // TODO - change the secrets below so that the defaults have
   // production-appropriate defaults, or no defaults at all, per
   // guidelines for using convict


### PR DESCRIPTION

## Problem

Closes #290 

## Solution

Specify exactly which app host is sending OTP mails, given as env var

- Declare a new convict config field - `appHost` - that specifies the
  application host name for the running backend process
- Specify `APP_HOST` in GitHub Workflows for injection into application
- Inject `appHost` into AuthService for use in OTP mails

## Deploy Notes

**New environment variables**:

- `APP_HOST` : The fully-qualified domain name of the application
