### PR TITLE
chore: add experimentalDecorators config in client

### DIFF
--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -17,6 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "react",
+    "experimentalDecorators": true,
   }
 }


### PR DESCRIPTION
This PR sets the `experimentalDecorators` flag to `true` in the client's `tsconfig.json` to suppress the following compiler errors. 
<img width="1076" alt="Screenshot 2021-03-29 at 5 33 02 PM" src="https://user-images.githubusercontent.com/19917616/112817279-d5c67c00-90b4-11eb-81a1-e99abe37c544.png">

Note: We attempted to use the `exclude` parameter: `exclude: ['../server']` to no avail.