### PR TITLE
fix: use sequelize-typescript v2 API for defining model class

### DIFF
--- a/src/server/checker/CheckerService.ts
+++ b/src/server/checker/CheckerService.ts
@@ -38,12 +38,7 @@ export class CheckerService {
           throw new Error(`User ${user.id} [${user.email}] not found`)
         }
 
-        const checkerInstance = await this.CheckerModel.create(
-          // FIX:
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (checker as any) as CheckerModel,
-          options
-        )
+        const checkerInstance = await this.CheckerModel.create(checker, options)
         // We definitely know that userInstance can add associations
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await (userInstance as any).addChecker(checkerInstance, options)

--- a/src/server/checker/__test__/CheckerService.spec.ts
+++ b/src/server/checker/__test__/CheckerService.spec.ts
@@ -48,9 +48,7 @@ describe('CheckerService', () => {
       await UserModel.destroy({ truncate: true })
     })
     it('returns false if checker exists', async () => {
-      // FIX:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await CheckerModel.create((checker as any) as CheckerModel)
+      await CheckerModel.create(checker)
 
       const created = await service.create(checker, user)
 

--- a/src/server/database/models/Checker.ts
+++ b/src/server/database/models/Checker.ts
@@ -11,7 +11,7 @@ import { User } from './User'
 import { UserToChecker } from './UserToChecker'
 
 @Table({ tableName: 'checkers', timestamps: true })
-export class Checker extends Model<Checker> {
+export class Checker extends Model {
   @Column({
     primaryKey: true,
     type: DataType.STRING,

--- a/src/server/database/models/User.ts
+++ b/src/server/database/models/User.ts
@@ -24,7 +24,7 @@ interface Settable {
 }
 
 @Table({ tableName: 'users', timestamps: true })
-export class User extends Model<User> {
+export class User extends Model {
   @Column({
     primaryKey: true,
     type: DataType.INTEGER,

--- a/src/server/database/models/UserToChecker.ts
+++ b/src/server/database/models/UserToChecker.ts
@@ -4,7 +4,7 @@ import { Checker } from './Checker'
 import { User } from './User'
 
 @Table({ tableName: 'usersToCheckers', timestamps: true })
-export class UserToChecker extends Model<UserToChecker> {
+export class UserToChecker extends Model {
   @ForeignKey(() => User)
   @Column
   userId!: number


### PR DESCRIPTION
This PR fixes the jankiness https://github.com/opengovsg/checkfirst/pull/285 that is:
> I had to do this strange type assertion chain here:
`const checkerInstance = await this.CheckerModel.create((checker as any) as CheckerModel, options)`

Turns out I was using the `sequelize-typescript` v1 API for defining a model whereas our version is ^2.1.0:
```
export class Checker extends Model<Checker> {
```

Whereas the new `sequelize-typescript` v2 API for defining a model is:
```
export class Checker extends Model {
```