### PR TITLE
fix: missing db hostname and added CSP env var to static lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,9 @@ functions:
     vpc:
       securityGroupIds:
         - ${env:VPC_SECURITY_GROUP_STATIC}
+    environment:
+      FRONTEND_SENTRY_DSN: ${env:FRONTEND_SENTRY_DSN}
+      CSP_REPORT_URI: ${env:CSP_REPORT_URI}
     events:
       - http:
           path: ""

--- a/src/server/database/config/config.ts
+++ b/src/server/database/config/config.ts
@@ -6,6 +6,7 @@ import { parse } from 'pg-connection-string'
 // connection parameters.
 const parsed = parse(config.get('databaseUrl'))
 const connectionConfig = {
+  host: parsed.host,
   username: parsed.user,
   port: parsed.port ? +parsed.port : 5432,
   password: parsed.password,


### PR DESCRIPTION
## Problem
- Database hostname was missing in the connection config
- CSP headers env var for static lambda were missing