### PR TITLE
fix(radio): avoid selecting default value

### DIFF
--- a/src/client/components/fields/RadioField.tsx
+++ b/src/client/components/fields/RadioField.tsx
@@ -22,7 +22,6 @@ export const RadioField: FC<Field> = ({ id, title, description, options }) => {
       name={id}
       control={control}
       rules={{ required: true }}
-      defaultValue={`${options[0]?.value}`}
       render={({ ref, value, onChange }, { invalid }) => (
         <FormControl isInvalid={invalid}>
           <FormLabel sx={styles.label} htmlFor={id}>


### PR DESCRIPTION

## Problem

Checkers currently render radio button groups with the first value selected,
potentially leading the user

## Solution

To avoid leading the user of a checker, do not set the form radio
option to any default value
