### PR TITLE
fix: preview checker UI to be in a card

### DIFF
--- a/src/client/components/builder/PreviewTab.tsx
+++ b/src/client/components/builder/PreviewTab.tsx
@@ -8,7 +8,15 @@ export const PreviewTab: FC = () => {
   const { config } = useCheckerContext()
 
   return (
-    <Container maxW="756px" px={0}>
+    <Container
+      mt="64px"
+      mb="64px"
+      maxW="xl"
+      pt="32px"
+      px="0px"
+      bg="white"
+      borderRadius="12px"
+    >
       <Checker config={config} />
     </Container>
   )


### PR DESCRIPTION
This PR puts the Preview Checker in a Card so that it is identical to the Preview Template page.

**UI screenshots**
This...
<img width="1552" alt="Screenshot 2021-04-07 at 11 49 16 AM" src="https://user-images.githubusercontent.com/19917616/113807997-adffa400-9797-11eb-8fea-a2dff1254cec.png">

now matches this
<img width="1552" alt="Screenshot 2021-04-07 at 11 49 14 AM" src="https://user-images.githubusercontent.com/19917616/113807989-ab9d4a00-9797-11eb-9881-0b382bed2a81.png">