### PR TITLE
fix: make active input bg white

### DIFF
--- a/src/client/components/builder/logic/CalculatedResult.tsx
+++ b/src/client/components/builder/logic/CalculatedResult.tsx
@@ -51,7 +51,6 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           name="expression"
           type="text"
           placeholder="Enter expression"
-          bg="#F4F6F9"
           fontFamily="mono"
           value={expression}
           onChange={(expression) =>

--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -177,7 +177,6 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             <Button variant="ghost">IF</Button>
           </Box>
           <ExpressionInput
-            bg="#F4F6F9"
             type="text"
             name="ifExpr"
             fontFamily="mono"
@@ -212,7 +211,6 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
               </MenuList>
             </Menu>
             <ExpressionInput
-              bg="#F4F6F9"
               type="text"
               fontFamily="mono"
               onChange={(expression) => updateCondition(i, { expression })}
@@ -246,7 +244,6 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             </Button>
           </Box>
           <ExpressionInput
-            bg="#F4F6F9"
             type="text"
             name="thenExpr"
             fontFamily="mono"
@@ -261,7 +258,6 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             </Button>
           </Box>
           <ExpressionInput
-            bg="#F4F6F9"
             type="text"
             name="elseExpr"
             fontFamily="mono"

--- a/src/client/components/builder/logic/MapResult.tsx
+++ b/src/client/components/builder/logic/MapResult.tsx
@@ -119,7 +119,11 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             <Button variant="ghost">MAP</Button>
           </Box>
           <Menu>
-            <MenuButton as={Button} rightIcon={<BiChevronDown />}>
+            <MenuButton
+              as={Button}
+              variant="outline"
+              rightIcon={<BiChevronDown />}
+            >
               {mapState.variableId ? mapState.variableId : 'SELECT INPUT'}
             </MenuButton>
             <MenuList>
@@ -167,7 +171,11 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             <Button variant="ghost">TO</Button>
           </Box>
           <Menu>
-            <MenuButton as={Button} rightIcon={<BiChevronDown />}>
+            <MenuButton
+              as={Button}
+              variant="outline"
+              rightIcon={<BiChevronDown />}
+            >
               {mapState.tableId ? mapState.tableId : 'SELECT MAP TABLE'}
             </MenuButton>
             <MenuList>


### PR DESCRIPTION
This PR fixes:
- the color of the valid input fields in the Calculated Result and Conditional Result logic components, and
- the map buttons in the Map Constants logic component. 

They were previously set to grey (which is used to indicate that the button is disabled).

#### Before fix:
<img width="898" alt="Screenshot 2021-04-09 at 5 54 23 PM" src="https://user-images.githubusercontent.com/19917616/114163352-a89f8680-995c-11eb-8060-e90350b0c089.png">
<img width="917" alt="Screenshot 2021-04-09 at 5 54 28 PM" src="https://user-images.githubusercontent.com/19917616/114163341-a5a49600-995c-11eb-9a00-6046a5816ff6.png">
<img width="929" alt="Screenshot 2021-04-09 at 6 22 08 PM" src="https://user-images.githubusercontent.com/19917616/114166581-83ad1280-9960-11eb-8b7e-f716c95388fc.png">


#### After fix:
<img width="898" alt="Screenshot 2021-04-09 at 5 47 51 PM" src="https://user-images.githubusercontent.com/19917616/114163124-6aa26280-995c-11eb-9d92-a200f7518dc7.png">
<img width="900" alt="Screenshot 2021-04-09 at 5 47 47 PM" src="https://user-images.githubusercontent.com/19917616/114163128-6d04bc80-995c-11eb-92c6-025d204758d0.png">
<img width="854" alt="Screenshot 2021-04-09 at 6 20 17 PM" src="https://user-images.githubusercontent.com/19917616/114166507-64ae8080-9960-11eb-97de-ae06d82f60d6.png">



Fixes https://github.com/opengovsg/checkfirst/issues/333