### PR TITLE
fix: make non-button components unclickable

### DIFF
--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -6,6 +6,7 @@ import {
   Divider,
   Button,
   IconButton,
+  Heading,
   VStack,
   HStack,
   Box,
@@ -173,8 +174,10 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
       </HStack>
       <VStack align="stretch" spacing={4}>
         <HStack>
-          <Box w="100px">
-            <Button variant="ghost">IF</Button>
+          <Box w="100px" pl={8}>
+            <Heading as="h5" size="sm">
+              IF
+            </Heading>
           </Box>
           <ExpressionInput
             bg="#F4F6F9"
@@ -240,10 +243,10 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
       <Divider />
       <VStack align="stretch" spacing={4}>
         <HStack>
-          <Box w="100px">
-            <Button w="100%" variant="ghost">
+          <Box w="100px" pl={8}>
+            <Heading as="h5" size="sm">
               THEN
-            </Button>
+            </Heading>
           </Box>
           <ExpressionInput
             bg="#F4F6F9"
@@ -255,10 +258,10 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           />
         </HStack>
         <HStack>
-          <Box w="100px">
-            <Button w="100%" variant="ghost">
+          <Box w="100px" pl={8}>
+            <Heading as="h5" size="sm">
               ELSE
-            </Button>
+            </Heading>
           </Box>
           <ExpressionInput
             bg="#F4F6F9"

--- a/src/client/components/builder/logic/MapResult.tsx
+++ b/src/client/components/builder/logic/MapResult.tsx
@@ -5,6 +5,7 @@ import { BiGitCompare, BiChevronDown } from 'react-icons/bi'
 import {
   Badge,
   Button,
+  Heading,
   VStack,
   HStack,
   Box,
@@ -115,8 +116,10 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
       </HStack>
       <VStack align="stretch" spacing={4}>
         <HStack>
-          <Box w="100px">
-            <Button variant="ghost">MAP</Button>
+          <Box w="100px" pl={8}>
+            <Heading as="h5" size="sm">
+              MAP
+            </Heading>
           </Box>
           <Menu>
             <MenuButton as={Button} rightIcon={<BiChevronDown />}>
@@ -163,8 +166,10 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           </Menu>
         </HStack>
         <HStack>
-          <Box w="100px">
-            <Button variant="ghost">TO</Button>
+          <Box w="100px" pl={8}>
+            <Heading as="h5" size="sm">
+              TO
+            </Heading>
           </Box>
           <Menu>
             <MenuButton as={Button} rightIcon={<BiChevronDown />}>


### PR DESCRIPTION
This PR makes the non-button components unclickable. Previously, the `IF`, `THEN`, `ELSE` buttons of the if/then and the `MAP` and `TO` buttons of the map logic components were clickable buttons.

#### Screenshots
<img width="913" alt="Screenshot 2021-04-09 at 6 08 40 PM" src="https://user-images.githubusercontent.com/19917616/114165343-edc4b800-995e-11eb-8b6c-36c12ab19fab.png">
<img width="915" alt="Screenshot 2021-04-09 at 6 06 48 PM" src="https://user-images.githubusercontent.com/19917616/114165350-f0271200-995e-11eb-87be-694a7ed332f2.png">


Fixes https://github.com/opengovsg/checkfirst/issues/330