### PR TITLE
fix: make the AND/OR button in the IF/ELSE component obvious

### DIFF
--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -1,7 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import { isValidExpression, math } from '../../../core/evaluator'
 import update from 'immutability-helper'
-import { BiGitBranch, BiPlusCircle, BiTrash } from 'react-icons/bi'
+import {
+  BiGitBranch,
+  BiPlusCircle,
+  BiTrash,
+  BiChevronDown,
+} from 'react-icons/bi'
 import {
   Divider,
   Button,
@@ -198,7 +203,11 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           <HStack key={i}>
             <Menu>
               <Box w="100px">
-                <MenuButton as={Button} variant="ghost">
+                <MenuButton
+                  as={Button}
+                  variant="outline"
+                  rightIcon={<BiChevronDown />}
+                >
                   {cond.type}
                 </MenuButton>
               </Box>


### PR DESCRIPTION
This PR makes the AND/OR button in the if else component more obvious by using the `outline` variant of the button and adding a down-chevron right icon.

#### Screenshot
<img width="208" alt="Screenshot 2021-04-09 at 6 17 21 PM" src="https://user-images.githubusercontent.com/19917616/114166159-f964ae80-995f-11eb-8b39-52831eb7b518.png">

Fixes https://github.com/opengovsg/checkfirst/issues/331
 