### PR TITLE
fix: sort references based on order in question and logic tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10918,9 +10918,9 @@
       }
     },
     "match-sorter": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.2.0.tgz",
-      "integrity": "sha512-yhmUTR5q6JP/ssR1L1y083Wp+C+TdR8LhYTxWI4IRgEUr8IXJu2mE6L3SwryCgX95/5J7qZdEg0G091sOxr1FQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "immutability-helper": "^3.1.1",
     "joi": "^17.4.0",
     "lodash": "^4.17.21",
-    "match-sorter": "^6.2.0",
+    "match-sorter": "^6.3.0",
     "mathjs": "^9.2.0",
     "minimatch": "^3.0.4",
     "morgan": "^1.10.0",

--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
+import { findIndex } from 'lodash'
 import {
   HStack,
   VStack,
@@ -10,11 +11,16 @@ import {
   Badge,
 } from '@chakra-ui/react'
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift'
-import { matchSorter } from 'match-sorter'
+import { matchSorter, RankingInfo } from 'match-sorter'
 
 import { useCheckerContext } from '../../../contexts'
 
 type Item = { id: string; type: 'FIELD' | 'OPERATION'; title: string }
+
+interface RankedItem extends RankingInfo {
+  item: Item
+  index: number
+}
 
 interface ExpressionInputProps extends Omit<InputProps, 'onChange'> {
   onChange: (expression: string) => void
@@ -26,8 +32,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
   ...props
 }) => {
   const { config } = useCheckerContext()
-
-  const getItems = (): Item[] => {
+  const items = useMemo<Item[]>(() => {
     let items: Item[] = []
     items = items.concat(
       config.fields.map(({ id, title }) => ({
@@ -46,7 +51,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
     )
 
     return items
-  }
+  }, [config.fields, config.operations])
 
   const getQueryString = (input?: string | null) => {
     if (!input) return ''
@@ -105,6 +110,15 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
     return changes
   }
 
+  const baseSort = (
+    { item: a }: RankedItem,
+    { item: b }: RankedItem
+  ): number => {
+    const itemAIndex = findIndex<Item>(items, (item) => item.id === a.id)
+    const itemBIndex = findIndex<Item>(items, (item) => item.id === b.id)
+    return itemAIndex < itemBIndex ? -1 : 1
+  }
+
   return (
     <Downshift
       initialInputValue={`${value}`}
@@ -152,8 +166,9 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
               w="100%"
               zIndex={99}
             >
-              {matchSorter(getItems(), getQueryString(inputValue), {
+              {matchSorter(items, getQueryString(inputValue), {
                 keys: ['id', 'title'],
+                baseSort,
               }).map((item, index) => (
                 <ListItem
                   {...getItemProps({ key: index, item })}

--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -110,6 +110,10 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
     return changes
   }
 
+  // The baseSort function is used to tie-break items that have the same ranking.
+  // This is useful in two main cases:
+  // - when the user types `@ `, we want to display all reference options on the Questions tab followed by the Logic tab; these reference options should be sorted according to their position on their respective tabs.
+  // - when the user types `@ <query>` and there are multiple reference options with titles that exactly match `<query>`, we want to sort these reference options according to their position on their Questions tab followed by the Logic tab.
   const baseSort = (
     { item: a }: RankedItem,
     { item: b }: RankedItem


### PR DESCRIPTION
## Problem

Closes #334 

## Solution
**Improvements**:
- Added `baseSort` in match-sorter options that specifies a sort order based on the position in `items`
- Refactored `items` to use `useMemo` hook to prevent repeated evaluation


## Before & After Screenshots

![image](https://user-images.githubusercontent.com/3666479/114440988-68aafe80-9bfd-11eb-8daa-33b7e756ed31.png)

![image](https://user-images.githubusercontent.com/3666479/114441020-71033980-9bfd-11eb-89df-4338c72fbf4a.png)


## Tests
- Create a checker with multiple fields
- Create a calculated result field and enter `@` in the input
- Press down to trigger auto-completion
- The order should be based on the position of the fields in the question tab
- All fields should also appear before operations

Note: If you entered a query string after `@`, the sort order will be first based on the closeness of the match (defined [here](https://github.com/kentcdodds/match-sorter#this-solution)), followed by the position in the checker.

