### PR TITLE
feat(hover-state-desc): add hover state descriptions to icon buttons

### DIFF
--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -250,13 +250,13 @@ export const createBuilderField = (
                 aria-label="Duplicate"
                 icon={
                   data.show ? (
-                    <DefaultTooltip label="Hide Result">
+                    <DefaultTooltip label="Hide result">
                       <span>
                         <BiShow />
                       </span>
                     </DefaultTooltip>
                   ) : (
-                    <DefaultTooltip label="Show Result">
+                    <DefaultTooltip label="Show result">
                       <span>
                         <BiHide />
                       </span>

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -15,6 +15,7 @@ import { usePosition } from '../../hooks/use-position'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
 import { ActionButton } from '../builder'
 import { BuilderAddPayload } from '../../../types/builder'
+import { DefaultTooltip } from '../common/DefaultTooltip'
 
 export type TitleFieldComponent = FC<
   Pick<checker.Checker, 'title' | 'description'>
@@ -247,7 +248,21 @@ export const createBuilderField = (
             {isOperationData(data) && (
               <ActionButton
                 aria-label="Duplicate"
-                icon={data.show ? <BiShow /> : <BiHide />}
+                icon={
+                  data.show ? (
+                    <DefaultTooltip label="Hide Result">
+                      <span>
+                        <BiShow />
+                      </span>
+                    </DefaultTooltip>
+                  ) : (
+                    <DefaultTooltip label="Show Result">
+                      <span>
+                        <BiHide />
+                      </span>
+                    </DefaultTooltip>
+                  )
+                }
                 onClick={handleDisplayToggle}
               />
             )}
@@ -255,12 +270,24 @@ export const createBuilderField = (
               <>
                 <ActionButton
                   aria-label="Duplicate"
-                  icon={<BiDuplicate />}
+                  icon={
+                    <DefaultTooltip label="Duplicate">
+                      <span>
+                        <BiDuplicate />
+                      </span>
+                    </DefaultTooltip>
+                  }
                   onClick={handleDuplicate}
                 />
                 <ActionButton
                   aria-label="Delete"
-                  icon={<BiTrash />}
+                  icon={
+                    <DefaultTooltip label="Delete">
+                      <span>
+                        <BiTrash />
+                      </span>
+                    </DefaultTooltip>
+                  }
                   onClick={handleDelete}
                 />
               </>

--- a/src/client/components/builder/EmbedModal.tsx
+++ b/src/client/components/builder/EmbedModal.tsx
@@ -51,7 +51,7 @@ const EmbedField: FC<EmbedFieldProps> = ({ name, value, children }) => {
           cursor="pointer"
           onClick={onClick}
           children={
-            <DefaultTooltip label="Copy link" placement="right">
+            <DefaultTooltip label="Copy" placement="right">
               <span>
                 <BiCopy />
               </span>

--- a/src/client/components/builder/EmbedModal.tsx
+++ b/src/client/components/builder/EmbedModal.tsx
@@ -23,6 +23,7 @@ import {
   useClipboard,
 } from '@chakra-ui/react'
 import { Checker } from '../../../types/checker'
+import { DefaultTooltip } from '../common/DefaultTooltip'
 
 type EmbedFieldProps = {
   name: string
@@ -49,7 +50,13 @@ const EmbedField: FC<EmbedFieldProps> = ({ name, value, children }) => {
         <InputRightElement
           cursor="pointer"
           onClick={onClick}
-          children={<BiCopy />}
+          children={
+            <DefaultTooltip label="Copy link" placement="right">
+              <span>
+                <BiCopy />
+              </span>
+            </DefaultTooltip>
+          }
         />
       </InputGroup>
     </FormControl>
@@ -76,12 +83,14 @@ export const EmbedModal: FC<EmbedModalProps> = ({
 
   return (
     <>
-      <IconButton
-        onClick={onEmbedOpen}
-        aria-label="Embed or Share"
-        variant="ghost"
-        icon={<BiCode size="24px" />}
-      />
+      <DefaultTooltip label="Embed or Share">
+        <IconButton
+          onClick={onEmbedOpen}
+          aria-label="Embed or Share"
+          variant="ghost"
+          icon={<BiCode size="24px" />}
+        />
+      </DefaultTooltip>
       <Modal isOpen={isEmbedOpen} onClose={onEmbedClose} size="lg">
         <ModalOverlay />
         <ModalContent>

--- a/src/client/components/builder/Navbar.tsx
+++ b/src/client/components/builder/Navbar.tsx
@@ -26,6 +26,7 @@ import {
 
 import { EmbedModal } from '.'
 import { useCheckerContext } from '../../contexts'
+import { DefaultTooltip } from '../common/DefaultTooltip'
 
 const ROUTES = ['questions', 'constants', 'logic']
 
@@ -177,11 +178,13 @@ export const Navbar: FC = () => {
           isChanged={isChanged}
         />
         <Link href={`/builder/${params.id}/preview`} isExternal>
-          <IconButton
-            aria-label="Preview"
-            variant="ghost"
-            icon={<BiShow size="24px" />}
-          />
+          <DefaultTooltip label="Preview">
+            <IconButton
+              aria-label="Preview"
+              variant="ghost"
+              icon={<BiShow size="24px" />}
+            />
+          </DefaultTooltip>
         </Link>
         <Button
           variant="outline"

--- a/src/client/components/builder/constants/MapTable.tsx
+++ b/src/client/components/builder/constants/MapTable.tsx
@@ -20,6 +20,7 @@ import * as checker from '../../../../types/checker'
 import { createBuilderField, ConstantFieldComponent } from '../BuilderField'
 import { useCheckerContext } from '../../../contexts'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { DefaultTooltip } from '../../common/DefaultTooltip'
 
 const InputComponent: ConstantFieldComponent = ({ constant, index }) => {
   const { title, table } = constant
@@ -125,14 +126,16 @@ const InputComponent: ConstantFieldComponent = ({ constant, index }) => {
                 value={value}
                 w="45%"
               />
-              <IconButton
-                borderRadius={0}
-                variant="ghost"
-                aria-label="delete item"
-                fontSize="20px"
-                icon={<BiTrash />}
-                onClick={() => handleDeleteTableRow(index)}
-              />
+              <DefaultTooltip label="Delete mapping" placement="right">
+                <IconButton
+                  borderRadius={0}
+                  variant="ghost"
+                  aria-label="delete item"
+                  fontSize="20px"
+                  icon={<BiTrash />}
+                  onClick={() => handleDeleteTableRow(index)}
+                />
+              </DefaultTooltip>
             </HStack>
           ))}
           <Button

--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -27,6 +27,7 @@ import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, OperationFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 import { ExpressionInput } from './ExpressionInput'
+import { DefaultTooltip } from '../../common/DefaultTooltip'
 
 interface Condition {
   type: 'AND' | 'OR'
@@ -192,13 +193,15 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             value={ifelseState.ifExpr}
           />
           <HStack>
-            <IconButton
-              variant="ghost"
-              aria-label="Add condition"
-              fontSize="20px"
-              onClick={addCondition}
-              icon={<BiPlusCircle />}
-            />
+            <DefaultTooltip label="Add Condition" placement="right">
+              <IconButton
+                variant="ghost"
+                aria-label="Add condition"
+                fontSize="20px"
+                onClick={addCondition}
+                icon={<BiPlusCircle />}
+              />
+            </DefaultTooltip>
           </HStack>
         </HStack>
         {ifelseState.conditions.map((cond, i) => (
@@ -229,20 +232,24 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
               value={cond.expression}
             />
             <HStack>
-              <IconButton
-                variant="ghost"
-                aria-label="Delete condition"
-                fontSize="20px"
-                onClick={() => deleteCondition(i)}
-                icon={<BiTrash />}
-              />
-              <IconButton
-                variant="ghost"
-                aria-label="Add condition"
-                fontSize="20px"
-                onClick={addCondition}
-                icon={<BiPlusCircle />}
-              />
+              <DefaultTooltip label="Delete Condition">
+                <IconButton
+                  variant="ghost"
+                  aria-label="Delete condition"
+                  fontSize="20px"
+                  onClick={() => deleteCondition(i)}
+                  icon={<BiTrash />}
+                />
+              </DefaultTooltip>
+              <DefaultTooltip label="Add Condition" placement="right">
+                <IconButton
+                  variant="ghost"
+                  aria-label="Add condition"
+                  fontSize="20px"
+                  onClick={addCondition}
+                  icon={<BiPlusCircle />}
+                />
+              </DefaultTooltip>
             </HStack>
           </HStack>
         ))}

--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -193,7 +193,7 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
             value={ifelseState.ifExpr}
           />
           <HStack>
-            <DefaultTooltip label="Add Condition" placement="right">
+            <DefaultTooltip label="Add condition" placement="right">
               <IconButton
                 variant="ghost"
                 aria-label="Add condition"
@@ -232,7 +232,7 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
               value={cond.expression}
             />
             <HStack>
-              <DefaultTooltip label="Delete Condition">
+              <DefaultTooltip label="Delete condition">
                 <IconButton
                   variant="ghost"
                   aria-label="Delete condition"
@@ -241,7 +241,7 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
                   icon={<BiTrash />}
                 />
               </DefaultTooltip>
-              <DefaultTooltip label="Add Condition" placement="right">
+              <DefaultTooltip label="Add condition" placement="right">
                 <IconButton
                   variant="ghost"
                   aria-label="Add condition"

--- a/src/client/components/common/DefaultTooltip.tsx
+++ b/src/client/components/common/DefaultTooltip.tsx
@@ -1,0 +1,17 @@
+import { Tooltip, TooltipProps } from '@chakra-ui/react'
+import React, { FC } from 'react'
+
+/**
+ * Wrapper for Chakra Tooltip with default props provided
+ *
+ * @see Docs     https://chakra-ui.com/components/tooltip
+ */
+export const DefaultTooltip: FC<TooltipProps> = ({ ...props }) => (
+  <Tooltip {...props} />
+)
+
+DefaultTooltip.defaultProps = {
+  gutter: 16,
+  openDelay: 800,
+  hasArrow: true,
+}

--- a/src/client/components/dashboard/CheckerCard.tsx
+++ b/src/client/components/dashboard/CheckerCard.tsx
@@ -15,6 +15,7 @@ import { Checker } from '../../../types/checker'
 import { getApiErrorMessage } from '../../api'
 import { CheckerService } from '../../services'
 import { ConfirmDialog } from '../ConfirmDialog'
+import { DefaultTooltip } from '../common/DefaultTooltip'
 
 type CheckerCardProps = {
   checker: Checker
@@ -66,8 +67,16 @@ export const CheckerCard: FC<CheckerCardProps> = ({ checker }) => {
             {checker.title}
           </Text>
           <HStack sx={styles.actions}>
-            <BiDuplicate onClick={onDuplicateClick} size="24px" />
-            <BiTrash onClick={onClickDelete} size="24px" />
+            <DefaultTooltip label="Duplicate">
+              <span>
+                <BiDuplicate onClick={onDuplicateClick} size="24px" />
+              </span>
+            </DefaultTooltip>
+            <DefaultTooltip label="Delete">
+              <span>
+                <BiTrash onClick={onClickDelete} size="24px" />
+              </span>
+            </DefaultTooltip>
           </HStack>
         </VStack>
       </Link>


### PR DESCRIPTION
## Problem

Currently there is no description of each icon when users hovers over it. To find out what the button/icon does, the user has to click on it first. This is not a good user experience.

Closes #263

## Solution

- Added tooltips for share checker, copy share links actions
- Added tooltips for dashboard duplicate and delete actions
- Added tooltips for builder field duplicate and delete actions
- Added tooltips for builder constant map delete actions
- Added tooltips for logic show/hide actions
- Added tooltips for logic conditional add and delete actions
- Added 800ms of opening delay before tooltips are shown

## Screenshots
<details>
<summary>Click here to show sample screenshots</summary>
<img width="1792" alt="Screenshot 2021-04-13 at 1 37 36 PM" src="https://user-images.githubusercontent.com/21305518/114504919-2f58aa00-9c62-11eb-9c15-b4fa084d0eda.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 09 28 PM" src="https://user-images.githubusercontent.com/21305518/114504925-31bb0400-9c62-11eb-886d-a0a3cda4283f.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 09 39 PM" src="https://user-images.githubusercontent.com/21305518/114504932-341d5e00-9c62-11eb-9559-d3d2787dc679.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 09 47 PM" src="https://user-images.githubusercontent.com/21305518/114504935-354e8b00-9c62-11eb-8f56-5bacadce6e72.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 09 58 PM" src="https://user-images.githubusercontent.com/21305518/114504940-367fb800-9c62-11eb-824c-120580eac641.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 10 09 PM" src="https://user-images.githubusercontent.com/21305518/114504942-37184e80-9c62-11eb-87bd-89d97cbec7cc.png">
<img width="1790" alt="Screenshot 2021-04-13 at 2 10 20 PM" src="https://user-images.githubusercontent.com/21305518/114504946-37b0e500-9c62-11eb-8405-aa4ff428c6cf.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 10 30 PM" src="https://user-images.githubusercontent.com/21305518/114504947-38497b80-9c62-11eb-9cfd-c7e16768785e.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 10 45 PM" src="https://user-images.githubusercontent.com/21305518/114504949-38e21200-9c62-11eb-8c4b-42b550348a3b.png">
<img width="1792" alt="Screenshot 2021-04-13 at 2 10 53 PM" src="https://user-images.githubusercontent.com/21305518/114504953-397aa880-9c62-11eb-90fc-851d7cdc779d.png">


</details>

## Tests

- [ ] Check that tooltips display for icons on dashboard (delete, duplicate)
- [ ] Check that tooltips display for sharing modal (share, copy link)
- [ ] Check that tooltips display in builder fields (delete, duplicate)
- [ ] Check that tooltips display in builder constant mapping modal (delete mapping)
- [ ] Check that tooltips display in builder logic fields (show result, hide result, delete, duplicate)
- [ ] Check that tooltips display in builder conditional logic fields (add, delete conditional)
- [ ] Check that all tooltips have a delay before showing up on hover