### PR TITLE
fix(types): fix types and resultant type errors

### DIFF
--- a/src/server/checker/CheckerController.ts
+++ b/src/server/checker/CheckerController.ts
@@ -50,6 +50,12 @@ export class CheckerController {
   get: (req: Request, res: Response) => Promise<void> = async (req, res) => {
     const { id } = req.params
     const { user } = req.session
+
+    if (!user) {
+      res.status(401).json({ message: 'User not signed in' })
+      return
+    }
+
     try {
       const checker = await this.service.retrieve(id, user)
       if (!checker) {

--- a/src/server/checker/CheckerService.ts
+++ b/src/server/checker/CheckerService.ts
@@ -76,7 +76,7 @@ export class CheckerService {
     return result
   }
 
-  retrieve: (id: string, user?: User) => Promise<Checker | null> = async (
+  retrieve: (id: string, user: User) => Promise<Checker | null> = async (
     id,
     user
   ) => {
@@ -85,7 +85,7 @@ export class CheckerService {
 
   retrievePublished: (
     id: string
-  ) => Promise<GetPublishedCheckerWithoutDraftCheckerDTO | undefined> = async (
+  ) => Promise<GetPublishedCheckerWithoutDraftCheckerDTO | null> = async (
     id
   ) => {
     const result = await this.PublishedCheckerModel.findOne({

--- a/src/server/checker/__test__/CheckerController.spec.ts
+++ b/src/server/checker/__test__/CheckerController.spec.ts
@@ -147,18 +147,15 @@ describe('CheckerController', () => {
       service.retrieve.mockReset()
     })
 
-    it('accepts non-authenticated get', async () => {
+    it('returns 401 on non-authenticated get', async () => {
       const app = express()
       app.use(bodyParser.json())
       app.use(sessionMiddleware({}))
       app.get('/c/drafts/:id', controller.get)
 
       service.retrieve.mockResolvedValue(checker)
-      const response = await request(app)
-        .get(`/c/drafts/${checker.id}`)
-        .expect(200)
-      expect(response.body).toStrictEqual(checker)
-      expect(service.retrieve).toHaveBeenCalledWith(checker.id, undefined)
+      await request(app).get(`/c/drafts/${checker.id}`).expect(401)
+      expect(service.retrieve).toHaveBeenCalledTimes(0)
     })
 
     it('allows authenticated get', async () => {

--- a/src/server/database/models/Checker.ts
+++ b/src/server/database/models/Checker.ts
@@ -33,7 +33,7 @@ export class Checker extends Model {
     type: DataType.TEXT,
     allowNull: true,
   })
-  description!: string
+  description?: string
 
   @Column({
     type: DataType.JSON,

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -1,6 +1,5 @@
 import { Checker as CheckerModel } from '../server/database/models/Checker'
 import { PublishedChecker as PublishedCheckerModel } from '../server/database/models/PublishedChecker'
-import { User } from './user'
 import { Unit } from 'mathjs'
 
 export type VariableResults = Record<
@@ -8,51 +7,40 @@ export type VariableResults = Record<
   string | number | Record<string, number> | Unit
 >
 
-export interface Checker {
-  id: string
-  title: string
-  description?: string
-  users?: User[]
-
-  fields: Field[]
-  constants: Constant[]
-  operations: Operation[]
-  displays: Display[]
-}
-
 export type Checker = Pick<
   CheckerModel,
-  'id',
-  'title',
-  'description',
-  'fields',
-  'constants',
-  'operations',
-  'displays'
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'fields'
+  | 'constants'
+  | 'operations'
+  | 'displays'
 >
 
 export type CreatePublishedCheckerDTO = Pick<
   CheckerModel,
-  'title',
-  'description',
-  'fields',
-  'constants',
-  'operations',
-  'displays'
+  | 'title'
+  | 'description'
+  | 'fields'
+  | 'constants'
+  | 'operations'
+  | 'displays'
+  | 'checkerId'
 >
 
 export type GetPublishedCheckerWithoutDraftCheckerDTO = Pick<
   PublishedCheckerModel,
-  'id',
-  'title',
-  'description',
-  'fields',
-  'constants',
-  'operations',
-  'displays',
-  'createdAt',
-  'updatedAt',
-  'checkerId'
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'fields'
+  | 'constants'
+  | 'operations'
+  | 'displays'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'checkerId'
 >
 
 export type ConfigArrayName = 'fields' | 'operations' | 'displays' | 'constants'

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,5 +1,5 @@
 import { User as UserModel } from '../server/database/models/User'
 
-export type User = Pick<UserModel, 'id', 'email'>
+export type User = Pick<UserModel, 'id' | 'email'>
 
 export default User


### PR DESCRIPTION
## Problem

Type aliases returns any instead of the specific type due to invalid Pick<> syntax being used (`,` was used to chain the fields we wanted to pick instead of `|`), which confused the TS compiler as there were too many arguments.

Closes #340

## Solution

Fix export types by replacing `,` with `|` and subsequently fix uncaught type errors within the codebase.

**Bug Fixes**:

- fix export types for checker and user .d.ts files
- fix Checker ORM Model typings
- fix related uncaught checker and auth type errors in checker-service and checker-controller