### PR TITLE
refactor(models): explicitly define timestamps in model class

### DIFF
--- a/src/server/database/models/Checker.ts
+++ b/src/server/database/models/Checker.ts
@@ -1,10 +1,12 @@
 import {
   BelongsToMany,
   Column,
+  CreatedAt,
   DataType,
   HasMany,
   Model,
   Table,
+  UpdatedAt,
 } from 'sequelize-typescript'
 
 import { Constant, Display, Field, Operation } from '../../../types/checker'
@@ -12,7 +14,7 @@ import { User } from './User'
 import { UserToChecker } from './UserToChecker'
 import { PublishedChecker } from './PublishedChecker'
 
-@Table({ tableName: 'checkers', timestamps: true })
+@Table({ tableName: 'checkers' })
 export class Checker extends Model {
   @Column({
     primaryKey: true,
@@ -64,4 +66,10 @@ export class Checker extends Model {
 
   @HasMany(() => PublishedChecker)
   publishedCheckers!: PublishedChecker[]
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
 }

--- a/src/server/database/models/PublishedChecker.ts
+++ b/src/server/database/models/PublishedChecker.ts
@@ -1,16 +1,18 @@
 import {
   BelongsTo,
   Column,
+  CreatedAt,
   DataType,
   ForeignKey,
   Model,
   Table,
+  UpdatedAt,
 } from 'sequelize-typescript'
 
 import { Constant, Display, Field, Operation } from '../../../types/checker'
 import { Checker } from './Checker'
 
-@Table({ tableName: 'publishedCheckers', timestamps: true })
+@Table({ tableName: 'publishedCheckers' })
 export class PublishedChecker extends Model {
   @Column({
     primaryKey: true,
@@ -61,4 +63,10 @@ export class PublishedChecker extends Model {
 
   @BelongsTo(() => Checker)
   checker!: Checker
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
 }

--- a/src/server/database/models/Template.ts
+++ b/src/server/database/models/Template.ts
@@ -1,7 +1,14 @@
-import { Column, DataType, Model, Table } from 'sequelize-typescript'
+import {
+  Column,
+  CreatedAt,
+  DataType,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
 import { Constant, Display, Field, Operation } from '../../../types/checker'
 
-@Table({ tableName: 'templates', timestamps: true })
+@Table({ tableName: 'templates' })
 export class Template extends Model {
   @Column({
     primaryKey: true,
@@ -44,4 +51,10 @@ export class Template extends Model {
     allowNull: false,
   })
   displays!: Display[]
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
 }

--- a/src/server/database/models/User.ts
+++ b/src/server/database/models/User.ts
@@ -1,9 +1,11 @@
 import {
   BelongsToMany,
   Column,
+  CreatedAt,
   DataType,
   Model,
   Table,
+  UpdatedAt,
 } from 'sequelize-typescript'
 import minimatch from 'minimatch'
 
@@ -23,7 +25,7 @@ interface Settable {
   setDataValue(key: string, value: unknown): void
 }
 
-@Table({ tableName: 'users', timestamps: true })
+@Table({ tableName: 'users' })
 export class User extends Model {
   @Column({
     primaryKey: true,
@@ -50,4 +52,10 @@ export class User extends Model {
 
   @BelongsToMany(() => Checker, () => UserToChecker)
   checkers!: Checker[]
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
 }

--- a/src/server/database/models/UserToChecker.ts
+++ b/src/server/database/models/UserToChecker.ts
@@ -1,9 +1,16 @@
-import { Column, ForeignKey, Model, Table } from 'sequelize-typescript'
+import {
+  Column,
+  CreatedAt,
+  ForeignKey,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
 
 import { Checker } from './Checker'
 import { User } from './User'
 
-@Table({ tableName: 'usersToCheckers', timestamps: true })
+@Table({ tableName: 'usersToCheckers' })
 export class UserToChecker extends Model {
   @ForeignKey(() => User)
   @Column
@@ -12,4 +19,10 @@ export class UserToChecker extends Model {
   @ForeignKey(() => Checker)
   @Column
   checkerId!: string
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
 }


### PR DESCRIPTION
## Problem

This PR explicitly defines timestamps in the model class so that we can create type aliases from these classes with the various timestamp fields.

Currently, we are unable to create - for example - a new type alias from `Checker` with an `updatedAt` field using the `Pick<>` utility. This is because the `Checker` class/interface does not have `updatedAt` explicitly defined in it.

Closes https://github.com/opengovsg/checkfirst/issues/391

## Solution

We explicitly define `updatedAt` and `createdAt` using their respective specific decorators (i.e. `@UpdatedAt` and `@CreatedAt`) within the model class.
