### PR TITLE
fix(create-new-modal): open builder upon successful checker creation

### DIFF
--- a/src/client/components/dashboard/CreateNewModal.tsx
+++ b/src/client/components/dashboard/CreateNewModal.tsx
@@ -1,5 +1,11 @@
 import React, { FC } from 'react'
-import { useParams, Switch, Redirect, Route } from 'react-router-dom'
+import {
+  useParams,
+  Switch,
+  Redirect,
+  Route,
+  useHistory,
+} from 'react-router-dom'
 import { useQueryClient, useQuery, useMutation } from 'react-query'
 import {
   useToast,
@@ -31,6 +37,7 @@ export type CreateNewModalProps = {
 }
 
 export const CreateNewModal: FC<CreateNewModalProps> = ({ onClose }) => {
+  const history = useHistory()
   const initial = {
     title: '',
     description: '',
@@ -103,6 +110,7 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({ onClose }) => {
         description: `${created?.title} has been created successfully`,
       })
       onClose()
+      history.push(`/builder/${created.id}`)
     },
     onError: (err) => {
       toast({


### PR DESCRIPTION
## Problem

When creating a new checker, if we only fill in the title field, checker opens into editor when clicking Create.
However, if you also fill in a description, the screen returns back to the dashboard when clicking Create.

Additionally, since the order of the checker is not based on recency (which will be tackled in issue #366), it takes some time to look for the checker that a user has created.

Closes #364 and #367

## Solution

**Bug Fixes**:

- fix `CreateNewModal` to open the editor once a checker is successfully created

## Tests

- [x] Check that the builder is opened with the correct title/description for each test
- [x] Check that the builder is opened after creating a checker from scratch
- [x] Check that the builder is opened after creating a checker from a template
- [x] Check that the builder is opened after creating a checker when duplicating another checker