### PR TITLE
fix(builder): select first operation by default

### DIFF
--- a/src/client/components/builder/ConstantsTab.tsx
+++ b/src/client/components/builder/ConstantsTab.tsx
@@ -27,6 +27,7 @@ import { MapTable } from './constants'
 import { useCheckerContext } from '../../contexts'
 
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+import useActiveIndex from '../../hooks/use-active-index'
 
 // Images
 import emptyConstantsTabImage from '../../assets/states/empty-constants.svg'
@@ -40,12 +41,12 @@ const generateDefaultMap = (id: number): checker.Constant => ({
 })
 
 export const ConstantsTab: FC = () => {
-  const [activeIndex, setActiveIndex] = useState<number>(0)
+  const { config, dispatch } = useCheckerContext()
+  const { constants } = config
+
+  const [activeIndex, setActiveIndex] = useActiveIndex(constants)
   const [offsetTop, setOffsetTop] = useState<number>(16)
   const [nextUniqueId, setNextUniqueId] = useState<number>(1)
-  const { config, dispatch } = useCheckerContext()
-
-  const { constants } = config
 
   useEffect(() => {
     let highestIndex = 0

--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -34,6 +34,7 @@ import {
   DateResult,
 } from '../builder/logic'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+import useActiveIndex from '../../hooks/use-active-index'
 
 // Images
 import emptyLogicTabImage from '../../assets/states/empty-logic.svg'
@@ -74,9 +75,7 @@ const generateDefaultDateOp = (id: number): checker.Operation => ({
 
 export const LogicTab: FC = () => {
   const { dispatch, config } = useCheckerContext()
-  const [activeIndex, setActiveIndex] = useState<number>(() =>
-    config.operations.length > 0 ? 0 : -1
-  )
+  const [activeIndex, setActiveIndex] = useActiveIndex(config.operations)
   const [offsetTop, setOffsetTop] = useState<number>(16)
   const [nextUniqueId, setNextUniqueId] = useState<number>(1)
 

--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -73,10 +73,12 @@ const generateDefaultDateOp = (id: number): checker.Operation => ({
 })
 
 export const LogicTab: FC = () => {
-  const [activeIndex, setActiveIndex] = useState<number>(0)
+  const { dispatch, config } = useCheckerContext()
+  const [activeIndex, setActiveIndex] = useState<number>(() =>
+    config.operations.length > 0 ? 0 : -1
+  )
   const [offsetTop, setOffsetTop] = useState<number>(16)
   const [nextUniqueId, setNextUniqueId] = useState<number>(1)
-  const { dispatch, config } = useCheckerContext()
 
   useEffect(() => {
     let highestIndex = 0

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -25,6 +25,7 @@ import {
 import { useCheckerContext } from '../../contexts'
 
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../util/enums'
+import useActiveIndex from '../../hooks/use-active-index'
 
 // Images
 import emptyQuestionsTabImage from '../../assets/states/empty-questions.svg'
@@ -98,12 +99,12 @@ const generateDefaultDateField = (id: number): checker.Field => ({
 export const TITLE_FIELD_ID = 'TITLE'
 
 export const QuestionsTab: FC = () => {
-  const [activeIndex, setActiveIndex] = useState<number>(-1)
+  const { config, dispatch } = useCheckerContext()
+  const { title, description, fields } = config
+
+  const [activeIndex, setActiveIndex] = useActiveIndex(fields)
   const [offsetTop, setOffsetTop] = useState<number>(16)
   const [nextUniqueId, setNextUniqueId] = useState<number>(1)
-  const { config, dispatch } = useCheckerContext()
-
-  const { title, description, fields } = config
 
   useEffect(() => {
     let highestIndex = 0

--- a/src/client/hooks/use-active-index.ts
+++ b/src/client/hooks/use-active-index.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { Field, Constant, Operation } from '../../types/checker'
+
+const useActiveIndex = (
+  items: Operation[] | Field[] | Constant[]
+): [number, (nextIndex: number) => void] => {
+  // Select first item by default if there are 1 or more items.
+  const [activeIndex, updateActiveIndex] = useState<number>(() =>
+    items.length > 0 ? 0 : -1
+  )
+
+  const setActiveIndex = (nextIndex: number) => {
+    updateActiveIndex((prevIndex) => {
+      // The only time we want to allow setting activeIndex to -1 is when there are no
+      // more items left.
+      const isRemoveLastItem =
+        prevIndex === 0 && nextIndex === -1 && items.length === 1
+      return isRemoveLastItem ? -1 : Math.max(nextIndex, 0)
+    })
+  }
+
+  return [activeIndex, setActiveIndex]
+}
+
+export default useActiveIndex


### PR DESCRIPTION
## Problem

`activeIndex` is initialised to `0` when there's no operation. After adding the first operation, `activeIndex` is incremented to `1`, which is an invalid index.

Closes #388 

## Solution

**Bug Fixes**:

- First operation should be selected by default if there is at least one operation

## Tests
- Create a new checker
- Create a new operation and observe the following:
   - Operation should be selected by default
   - Shift up/down should be disabled