### PR TITLE
feat(dashboard): add timestamps to checker cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "match-sorter": "^6.3.0",
     "mathjs": "^9.3.2",
     "minimatch": "^3.0.4",
+    "moment-timezone": "0.5.33",
     "morgan": "^1.10.0",
     "nodemailer": "^6.4.17",
     "otplib": "^12.0.1",

--- a/src/client/components/dashboard/CheckerCard.tsx
+++ b/src/client/components/dashboard/CheckerCard.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react'
+import moment from 'moment-timezone'
 import { useQueryClient, useMutation } from 'react-query'
 import { useHistory, useRouteMatch, Link } from 'react-router-dom'
 import { BiDuplicate, BiTrash } from 'react-icons/bi'
@@ -11,14 +12,14 @@ import {
   HStack,
 } from '@chakra-ui/react'
 
-import { Checker } from '../../../types/checker'
+import { DashboardCheckerDTO } from '../../../types/checker'
 import { getApiErrorMessage } from '../../api'
 import { CheckerService } from '../../services'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { DefaultTooltip } from '../common/DefaultTooltip'
 
 type CheckerCardProps = {
-  checker: Checker
+  checker: DashboardCheckerDTO
 }
 
 export const CheckerCard: FC<CheckerCardProps> = ({ checker }) => {
@@ -65,6 +66,11 @@ export const CheckerCard: FC<CheckerCardProps> = ({ checker }) => {
         <VStack sx={styles.card} align="stretch" role="group">
           <Text flex={1} sx={styles.title} isTruncated>
             {checker.title}
+          </Text>
+          <Text flex={1} sx={styles.subtitle} isTruncated>
+            {moment(checker.updatedAt)
+              .tz('Asia/Singapore')
+              .format('DD MMM, YYYY')}
           </Text>
           <HStack sx={styles.actions}>
             <DefaultTooltip label="Duplicate">

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -23,7 +23,7 @@ import {
   CreateNewModal,
   PreviewTemplate,
 } from '../components/dashboard'
-import { Checker } from '../../types/checker'
+import { DashboardCheckerDTO } from '../../types/checker'
 import { CheckerService } from '../services'
 
 export const Dashboard: FC = () => {
@@ -31,7 +31,7 @@ export const Dashboard: FC = () => {
   const { path } = useRouteMatch()
   const { isLoading, data: checkers } = useQuery('checkers', async () => {
     const response = await CheckerService.listCheckers()
-    return response as Checker[]
+    return response as DashboardCheckerDTO[]
   })
 
   return (

--- a/src/client/theme/components/CheckerCard.tsx
+++ b/src/client/theme/components/CheckerCard.tsx
@@ -15,6 +15,11 @@ export const CheckerCard = {
       fontSize: '16px',
       fontWeight: '600',
     },
+    subtitle: {
+      fontSize: '14px',
+      fontWeight: '500',
+      color: '#767676',
+    },
     actions: {
       visibility: 'hidden',
       justifyContent: 'center',

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -18,6 +18,18 @@ export type Checker = Pick<
   | 'displays'
 >
 
+export type DashboardCheckerDTO = Pick<
+  CheckerModel,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'fields'
+  | 'constants'
+  | 'operations'
+  | 'displays'
+  | 'updatedAt'
+>
+
 export type CreatePublishedCheckerDTO = Pick<
   CheckerModel,
   | 'title'


### PR DESCRIPTION
## Problem

There is currently no date created/ date modified preview on the checker cards on the homepage. This makes it hard for users to distinguish between recently modified checkers and old checkers

Closes #337

## Solution

- add timestamps to checker cards
- add `DashboardCheckerDTO` to facilitate retrieval of last updated date

## Before & After Screenshots

**BEFORE**:
<img width="1792" alt="Screenshot 2021-04-20 at 6 28 47 PM" src="https://user-images.githubusercontent.com/21305518/115381616-508f3c80-a206-11eb-939f-5fb12903bb08.png">

**AFTER**:
<img width="1792" alt="Screenshot 2021-04-20 at 6 28 20 PM" src="https://user-images.githubusercontent.com/21305518/115381725-6dc40b00-a206-11eb-8fe0-1954e856addf.png">

## Tests

- [x] Check that the last updated timestamp is displayed for all checkers on the dashboard
- [x] Check that updating a checker updates the timestamp

## Deploy Notes

**New dependencies**:

- `moment-timezone: 0.5.33`: formats js date into readable format
