### PR TITLE
chore(deps): downgrade history from 5.0.0 to 4.10.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8759,11 +8759,16 @@
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
-        "@babel/runtime": "^7.7.6"
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "framer-motion": "^4.0.0",
     "graphlib": "^2.1.8",
     "helmet": "^4.4.1",
-    "history": "^5.0.0",
+    "history": "^4.10.1",
     "immutability-helper": "^3.1.1",
     "joi": "^17.4.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Reverts opengovsg/checkfirst#380

> I'm going to revert this upgrade because it seems that `5.0.0` is [used in react router 6](https://github.com/ReactTraining/history#readme) and Sentry [only supports](https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/) up to react router 5. I think our CI didn't catch it because the error is only thrown at the build step. 