### PR TITLE
chore: add compile job to catch compilation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,26 @@ jobs:
       - run: npm ci
       - run: npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
       - run: npm run lint
+  compile:
+    name: Compile
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci
+      - run: npm run build
   test:
     name: Test
     runs-on: ubuntu-18.04
@@ -47,7 +67,6 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - run: npm ci
-      - run: npm run build
       - run: npm test
   gatekeep:
     name: Determine if Build & Deploy is needed
@@ -69,7 +88,7 @@ jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-18.04
-    needs: [test, lint, gatekeep]
+    needs: [test, lint, compile, gatekeep]
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - run: npm ci
+      - run: npm run build
       - run: npm test
   gatekeep:
     name: Determine if Build & Deploy is needed


### PR DESCRIPTION
## Problem

Compilation failures are not caught by our non-deploy CI workflow currently. This results in potential compilation failures to be missed until we attempt to deploy to staging.

## Solution

**Improvements**:
- Add job to run build to catch possible typescript/webpack compilation failures
