### PR TITLE
fix(checker): fix overscroll behaviour on embedded checkers

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -149,7 +149,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
 
   return (
     <StylesProvider value={styles}>
-      <Container maxW="xl" p={8} mb={4}>
+      <Container maxW="xl" p={8} mb={4} overscroll-behaviour="contain">
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <VStack align="stretch" spacing={10}>

--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -132,6 +132,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
       setVariables(computed)
       outcomes.current?.scrollIntoView({
         behavior: 'smooth',
+        block: 'nearest',
       })
     } catch (err) {
       toast({

--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -149,7 +149,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
 
   return (
     <StylesProvider value={styles}>
-      <Container maxW="xl" p={8} mb={4} overscroll-behaviour="contain">
+      <Container maxW="xl" p={8} mb={4} sx={{ overscrollBehavior: 'contain' }}>
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <VStack align="stretch" spacing={10}>


### PR DESCRIPTION
## Problem

fix overscroll behaviour on embedded checkers

Closes #421

## Solution

**Features**:

- set `overscroll-behaviour` to `contain`
