### PR TITLE
refactor: collapse results to column layout in mobile view

### DIFF
--- a/src/client/components/displays/LineDisplay.tsx
+++ b/src/client/components/displays/LineDisplay.tsx
@@ -1,5 +1,9 @@
 import React, { FC } from 'react'
-import { HStack, Text } from '@chakra-ui/react'
+import { Stack, Text, useMultiStyleConfig } from '@chakra-ui/react'
+
+// If the value is over this threshold, the result will be rendered as horizontal
+// regardless of whether it is in mobile view.
+const OVERFLOW_LENGTH = 25
 
 interface LineDisplayProps {
   label: string
@@ -7,10 +11,15 @@ interface LineDisplayProps {
 }
 
 export const LineDisplay: FC<LineDisplayProps> = ({ label, value }) => {
+  const isOverflow = value.length > OVERFLOW_LENGTH
+  const styles = useMultiStyleConfig('LineDisplay', {
+    variant: isOverflow ? 'column' : 'base',
+  })
+
   return (
-    <HStack justifyContent="space-between">
-      <Text flex={1}>{label}</Text>
-      <Text fontWeight="bold">{value}</Text>
-    </HStack>
+    <Stack sx={styles.container} spacing="8px">
+      <Text sx={styles.label}>{label}</Text>
+      <Text sx={styles.value}>{value}</Text>
+    </Stack>
   )
 }

--- a/src/client/theme/components/LineDisplay.ts
+++ b/src/client/theme/components/LineDisplay.ts
@@ -13,6 +13,7 @@ export const LineDisplay = {
     },
     value: {
       w: { base: '100%', md: '25%' },
+      textAlign: { base: 'left', md: 'right' },
       fontWeight: 'bold',
       fontSize: '24px',
       lineHeight: '32px',
@@ -28,6 +29,7 @@ export const LineDisplay = {
       },
       value: {
         w: '100%',
+        textAlign: 'left',
       },
     },
   },

--- a/src/client/theme/components/LineDisplay.ts
+++ b/src/client/theme/components/LineDisplay.ts
@@ -1,0 +1,34 @@
+export const LineDisplay = {
+  parts: ['container', 'label', 'value'],
+  baseStyle: {
+    container: {
+      flexDirection: { base: 'column', md: 'row' },
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    label: {
+      fontSize: '16px',
+      lineHeight: '24px',
+      w: { base: '100%', md: '75%' },
+    },
+    value: {
+      w: { base: '100%', md: '25%' },
+      fontWeight: 'bold',
+      fontSize: '24px',
+      lineHeight: '32px',
+    },
+  },
+  variants: {
+    column: {
+      container: {
+        flexDirection: 'column',
+      },
+      label: {
+        w: '100%',
+      },
+      value: {
+        w: '100%',
+      },
+    },
+  },
+}

--- a/src/client/theme/components/index.ts
+++ b/src/client/theme/components/index.ts
@@ -2,10 +2,12 @@ import { BuilderField } from './BuilderField'
 import { FloatingToolbar } from './FloatingToolbar'
 import { CheckerCard } from './CheckerCard'
 import { Checker } from './Checker'
+import { LineDisplay } from './LineDisplay'
 
 export const components = {
   BuilderField,
   FloatingToolbar,
   CheckerCard,
   Checker,
+  LineDisplay,
 }


### PR DESCRIPTION
## Problem

Closes #432

## Solution
- Collapse results into a columnar layout when:
  - Checker is viewed on a mobile device
  - Value of the result is more than 25 characters long. Remaining as a row reduces readability of the result. 

## Before & After Screenshots
<details>
<summary>Mobile view</summary>
<img src='https://user-images.githubusercontent.com/3666479/116105920-5bedd680-a6e4-11eb-8cb3-efa206a3198b.png' />
</details>

<details>
<summary>Desktop column view</summary>
<img src='https://user-images.githubusercontent.com/3666479/116106026-71630080-a6e4-11eb-9442-7ce864350b47.png' />
</details>

## Tests
- [ ] View results on a mobile device and verify that they are shown in a columnar layout
- [ ] Create a result that has a long result value (e.g MinLaw checker). The result should be displayed in a columnar layout regardless of whether it is viewed on a desktop or mobile device. 