### PR TITLE
fix(create-modal): enable create when description is empty

### DIFF
--- a/src/client/components/dashboard/CreateNewModal.tsx
+++ b/src/client/components/dashboard/CreateNewModal.tsx
@@ -49,7 +49,7 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({ onClose }) => {
 
   const toast = useToast({ position: 'bottom-right', variant: 'solid' })
   const { trigger, register, handleSubmit, formState, setValue } = useForm({
-    mode: 'onBlur',
+    mode: 'onChange',
   })
   const { isValid, errors } = formState
 
@@ -157,7 +157,7 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({ onClose }) => {
             <form onSubmit={handleSubmit(onSubmit)}>
               <ModalBody>
                 <VStack spacing={4}>
-                  <FormControl isInvalid={!!errors.description}>
+                  <FormControl isInvalid={!!errors.title}>
                     <FormLabel htmlFor="id">Title</FormLabel>
                     <Input
                       isDisabled={isCheckerLoading || isTemplateLoading}
@@ -166,8 +166,8 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({ onClose }) => {
                     />
                     <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
                   </FormControl>
-                  <FormControl isInvalid={!!errors.title}>
-                    <FormLabel htmlFor="id">Description</FormLabel>
+                  <FormControl>
+                    <FormLabel htmlFor="description">Description</FormLabel>
                     <Textarea
                       isDisabled={isCheckerLoading || isTemplateLoading}
                       name="description"


### PR DESCRIPTION
## Problem

Closes #363 

## Solution

**Improvements**:

- Validate `onChange` instead of `onBlur`

**Bug fixes**
- Corrected error references for `isInvalid`

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/116196917-a748c900-a766-11eb-8de2-08b16546aeaa.png)

## Tests
- [x] Choose "Create from scratch" and enter a title. Create button should be enabled the moment
- [x] Enter text in title and then delete it. It should now show that "Title is required".