### PR TITLE
fix: reduce opacity for hidden logic blocks

### DIFF
--- a/src/client/components/builder/logic/CalculatedResult.tsx
+++ b/src/client/components/builder/logic/CalculatedResult.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { BiCalculator } from 'react-icons/bi'
-import { VStack, HStack, Box, Text, Input } from '@chakra-ui/react'
+import { VStack, HStack, Box, Input } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, OperationFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 import { ExpressionInput } from './ExpressionInput'
+import { FormulaPreview } from './FormulaPreview'
 
 const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   const { title, expression } = operation
@@ -63,15 +64,14 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
 }
 
 const PreviewComponent: OperationFieldComponent = ({ operation }) => {
-  const { title, expression } = operation
+  const { show, title, expression } = operation
   return (
-    <VStack align="stretch" w="50%" spacing={4}>
-      <HStack>
-        <BiCalculator fontSize="20px" />
-        <Text>{title}</Text>
-      </HStack>
-      <Text fontFamily="mono">{expression}</Text>
-    </VStack>
+    <FormulaPreview
+      show={show}
+      title={title}
+      expression={expression}
+      icon={BiCalculator}
+    />
   )
 }
 

--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -15,7 +15,6 @@ import {
   VStack,
   HStack,
   Box,
-  Text,
   Input,
   Menu,
   MenuButton,
@@ -28,6 +27,7 @@ import { createBuilderField, OperationFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 import { ExpressionInput } from './ExpressionInput'
 import { DefaultTooltip } from '../../common/DefaultTooltip'
+import { FormulaPreview } from './FormulaPreview'
 
 interface Condition {
   type: 'AND' | 'OR'
@@ -290,15 +290,14 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
 }
 
 const PreviewComponent: OperationFieldComponent = ({ operation }) => {
-  const { title, expression } = operation
+  const { show, title, expression } = operation
   return (
-    <VStack align="stretch" w="100%" spacing={4}>
-      <HStack>
-        <BiGitBranch fontSize="20px" />
-        <Text>{title}</Text>
-      </HStack>
-      <Text fontFamily="mono">{expression}</Text>
-    </VStack>
+    <FormulaPreview
+      show={show}
+      title={title}
+      expression={expression}
+      icon={BiGitBranch}
+    />
   )
 }
 

--- a/src/client/components/builder/logic/DateResult.tsx
+++ b/src/client/components/builder/logic/DateResult.tsx
@@ -20,6 +20,7 @@ import {
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, OperationFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { FormulaPreview } from './FormulaPreview'
 import update from 'immutability-helper'
 
 interface DateState {
@@ -188,15 +189,14 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
 }
 
 const PreviewComponent: OperationFieldComponent = ({ operation }) => {
-  const { title, expression } = operation
+  const { show, title, expression } = operation
   return (
-    <VStack align="stretch" w="50%" spacing={4}>
-      <HStack>
-        <BiCalendar fontSize="20px" />
-        <Text>{title}</Text>
-      </HStack>
-      <Text fontFamily="mono">{expression}</Text>
-    </VStack>
+    <FormulaPreview
+      show={show}
+      title={title}
+      expression={expression}
+      icon={BiCalendar}
+    />
   )
 }
 

--- a/src/client/components/builder/logic/FormulaPreview.tsx
+++ b/src/client/components/builder/logic/FormulaPreview.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react'
+import { IconType } from 'react-icons'
+import { VStack, HStack, Text } from '@chakra-ui/react'
+
+interface FormulaPreviewProps {
+  show: boolean
+  title: string
+  expression: string
+  icon: IconType
+}
+
+export const FormulaPreview: FC<FormulaPreviewProps> = ({
+  show,
+  title,
+  expression,
+  icon: Icon,
+}) => {
+  return (
+    <VStack align="stretch" w="50%" spacing={4} opacity={show ? 1 : 0.5}>
+      <HStack>
+        <Icon fontSize="20px" />
+        <Text>{title}</Text>
+      </HStack>
+      <Text fontFamily="mono">{expression}</Text>
+    </VStack>
+  )
+}

--- a/src/client/components/builder/logic/MapResult.tsx
+++ b/src/client/components/builder/logic/MapResult.tsx
@@ -20,6 +20,7 @@ import {
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, OperationFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { FormulaPreview } from './FormulaPreview'
 
 interface MapState {
   tableId: string
@@ -211,15 +212,14 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
 }
 
 const PreviewComponent: OperationFieldComponent = ({ operation }) => {
-  const { title, expression } = operation
+  const { show, title, expression } = operation
   return (
-    <VStack align="stretch" w="100%" spacing={4}>
-      <HStack>
-        <BiGitCompare fontSize="20px" />
-        <Text>{title}</Text>
-      </HStack>
-      <Text fontFamily="mono">{expression}</Text>
-    </VStack>
+    <FormulaPreview
+      show={show}
+      title={title}
+      expression={expression}
+      icon={BiGitCompare}
+    />
   )
 }
 


### PR DESCRIPTION
## Problem

Closes #332 

## Solution

**Bug Fixes**:

- Apply reduced opacity for hidden logic blocks.

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/116960529-39a31c80-acd3-11eb-8706-886d394c6f00.png)

## Tests
- [ ] Calculated result has reduced opacity when hidden
- [ ] Map result has reduced opacity when hidden
- [ ] Conditional result has reduced opacity when hidden
- [ ] Date result has reduced opacity when hidden