### PR TITLE
feat(landing-navbar): add contact us link to landing navbar

### DIFF
--- a/src/client/pages/Landing/components/LandingNavbar.tsx
+++ b/src/client/pages/Landing/components/LandingNavbar.tsx
@@ -22,6 +22,14 @@ export const LandingNavbar: FC<{ login: () => void }> = ({ login }) => (
       <Box>
         <Link
           color="primary.500"
+          href="https://go.gov.sg/checkfirst-contact"
+          mr={6}
+          isExternal
+        >
+          Contact Us
+        </Link>
+        <Link
+          color="primary.500"
           href="https://guide.checkfirst.gov.sg"
           isExternal
         >


### PR DESCRIPTION
## Problem

Provide users an avenue to reach us when they need help or has questions instead of just going to the guide directly.
Particularly useful for new use cases or feature requests.

Closes #477

## Solution

**Features**:

- Add contact us link to the landing navbar

## Screenshots

![Screenshot 2021-05-04 at 7 18 55 AM](https://user-images.githubusercontent.com/21305518/116970233-2f404d00-acea-11eb-9518-3fe87bc4ce15.png)

## Tests

- [ ] Check that clicking contact us redirects to [go.gov.sg/checkfirst-contact](https://go.gov.sg/checkfirst-contact)
