### PR TITLE
chore(builder): add GA to help button

### DIFF
--- a/src/client/components/builder/HelpButton.tsx
+++ b/src/client/components/builder/HelpButton.tsx
@@ -1,19 +1,26 @@
-import { Circle, Flex, Link } from '@chakra-ui/react'
+import { OutboundLink } from 'react-ga'
+import { Circle, Flex } from '@chakra-ui/react'
 import React, { FC } from 'react'
 import { BiQuestionMark } from 'react-icons/bi'
+import { useGoogleAnalytics } from '../../contexts'
 import { DefaultTooltip } from '../common/DefaultTooltip'
 
 export const HelpButton: FC = () => {
+  const { GA_USER_EVENTS } = useGoogleAnalytics()
   return (
     <>
       <Flex position="fixed" left="40px" bottom="40px">
-        <Link href="https://guide.checkfirst.gov.sg" isExternal>
+        <OutboundLink
+          to="https://guide.checkfirst.gov.sg"
+          target="_blank"
+          eventLabel={GA_USER_EVENTS.BUILDER_HELP_BUTTON}
+        >
           <DefaultTooltip label="Help & Resources" placement="right">
             <Circle size="40px" bg="primary.500" color="white">
               <BiQuestionMark size="24px" />
             </Circle>
           </DefaultTooltip>
-        </Link>
+        </OutboundLink>
       </Flex>
     </>
   )

--- a/src/client/contexts/GoogleAnalyticsContext.tsx
+++ b/src/client/contexts/GoogleAnalyticsContext.tsx
@@ -13,9 +13,7 @@ const {
 } = GoogleAnalyticsService
 
 interface GoogleAnalyticsContextProps {
-  GA_USER_EVENTS: {
-    SUBMIT: string
-  }
+  GA_USER_EVENTS: typeof GA_USER_EVENTS
   setGAUserId: (userId: number | null) => void
   sendPageView: (path: string) => void
   sendUserEvent: (action: string, label?: string, value?: number) => void

--- a/src/client/services/GoogleAnalyticsService.tsx
+++ b/src/client/services/GoogleAnalyticsService.tsx
@@ -4,6 +4,7 @@ const GA_TRACKING_ID = process.env.GA_TRACKING_ID || ''
 
 const GA_USER_EVENTS = {
   SUBMIT: 'Submit',
+  BUILDER_HELP_BUTTON: 'Builder Help Button',
 }
 
 const initializeGA = (): void => {


### PR DESCRIPTION
## Problem

Natalie wanted to know how many people were trying out the help button on the dashboard

## Solution

**Improvements**
- Add GA event when user clicks on help button in the builder