### PR TITLE
chore: center align guide link in dashboard

### DIFF
--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -44,9 +44,11 @@ const EmptyDashboardBody: FC = () => (
       </Heading>
       <Text>
         Start from scratch or use one of our templates. <br />
-        <Link href={GET_STARTED_URL} isExternal color="#1B3C87">
-          Learn how to get started
-        </Link>
+        <Center>
+          <Link href={GET_STARTED_URL} isExternal color="#1B3C87">
+            Learn how to get started
+          </Link>
+        </Center>
       </Text>
       <Image
         flex={1}


### PR DESCRIPTION
As requested by @NatMaeTan 

### Before
<img width="411" alt="Screenshot 2021-05-05 at 10 43 46 AM" src="https://user-images.githubusercontent.com/19917616/117095549-396d5480-ad99-11eb-8540-1da5a1d3a765.png">

### After
<img width="412" alt="Screenshot 2021-05-05 at 11 36 58 AM" src="https://user-images.githubusercontent.com/19917616/117095494-1a6ec280-ad99-11eb-8aaf-2d24504a1630.png">


