### PR TITLE
fix: set correct initial condition type for if/else

### DIFF
--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -98,10 +98,15 @@ const toExpression = (state: IfelseState): string => {
 const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   const { title, expression } = operation
   const { dispatch } = useCheckerContext()
-  const [conditionType, setConditionType] = useState(ConditionType.And)
   const [ifelseState, setIfelseState] = useState<IfelseState>(
     fromExpression(expression)
   )
+  // Retrieve condition type from ifelseState if there exist conditions; else use AND type as default
+  const initialConditionType =
+    ifelseState.conditions.length > 0
+      ? ifelseState.conditions[0].type
+      : ConditionType.And
+  const [conditionType, setConditionType] = useState(initialConditionType)
 
   useEffect(() => {
     const updatedExpr = toExpression(ifelseState)


### PR DESCRIPTION
The if/else component was setting the default initial condition type as `AND` - even though the existing if/else component has an `OR` condition type. This results in a bug where the preview component/expression correctly uses the `OR` condition type, while the input component uses the default `AND` condition type.

### Preview component
<img width="914" alt="Screenshot 2021-05-05 at 3 42 58 PM" src="https://user-images.githubusercontent.com/19917616/117110488-c247b880-adb8-11eb-9eb1-b214418e8a59.png">

### Input component

<img width="938" alt="Screenshot 2021-05-05 at 3 42 55 PM" src="https://user-images.githubusercontent.com/19917616/117110499-c70c6c80-adb8-11eb-84b0-6402957d5b28.png">

