### PR TITLE
fix(default-tooltip): close tooltip on mouse down and click

### DIFF
--- a/src/client/components/common/DefaultTooltip.tsx
+++ b/src/client/components/common/DefaultTooltip.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react'
  * @see Docs     https://chakra-ui.com/components/tooltip
  */
 export const DefaultTooltip: FC<TooltipProps> = ({ ...props }) => (
-  <Tooltip {...props} />
+  <Tooltip {...props} closeOnMouseDown closeOnClick />
 )
 
 DefaultTooltip.defaultProps = {


### PR DESCRIPTION
## Problem

Add condition tooltip doesn't disappear after non-hover and seems to be stuck in place

Closes #499

## Solution

Update default tooltip to close tooltips on mouse down and click
