### PR TITLE
fix(expression-input): fix query string replacement inputvalues not updating correctly

### DIFF
--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -128,14 +128,12 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
           state?.inputValue,
           changes?.inputValue
         )
-        onChange(newInputValue)
         return {
           ...changes,
           inputValue: newInputValue,
         }
       }
       case Downshift.stateChangeTypes.changeInput:
-        onChange(changes.inputValue || '')
         return {
           ...changes,
         }
@@ -170,6 +168,9 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
       onSelect={() => {
         // updates the cursor after onSelect is triggered
         inputRef.current?.setSelectionRange(caretPos.current, caretPos.current)
+      }}
+      onInputValueChange={(inputValue) => {
+        onChange(inputValue)
       }}
       itemToString={(item) => item?.id || ''}
     >


### PR DESCRIPTION
## Problem

Whenever a query string replacement occurs, the input value is not updated correctly, which is unexpected behaviour for expression inputs.

## Solution

Update where onChange is called to after the state reducer is run to ensure that the latest state is captured for updates.
