### PR TITLE
fix(expression-input): hotfix to fix onchange trigger

### DIFF
--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -123,16 +123,14 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
   ) => {
     switch (changes.type) {
       case Downshift.stateChangeTypes.clickItem:
-      case Downshift.stateChangeTypes.keyDownEnter: {
-        const newInputValue = replaceVariableName(
-          state?.inputValue,
-          changes?.inputValue
-        )
+      case Downshift.stateChangeTypes.keyDownEnter:
         return {
           ...changes,
-          inputValue: newInputValue,
+          inputValue: replaceVariableName(
+            state?.inputValue,
+            changes?.inputValue
+          ),
         }
-      }
       case Downshift.stateChangeTypes.changeInput:
         return {
           ...changes,
@@ -169,8 +167,8 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
         // updates the cursor after onSelect is triggered
         inputRef.current?.setSelectionRange(caretPos.current, caretPos.current)
       }}
-      onInputValueChange={(inputValue) => {
-        onChange(inputValue)
+      onStateChange={(_, state) => {
+        onChange(state.inputValue || '')
       }}
       itemToString={(item) => item?.id || ''}
     >


### PR DESCRIPTION
## Problem

Currently, Downshift's `onInputValueChange` event handler runs before the state reducer is able to update the input value, thus returning the wrong value to the `onChange` callback function.

## Solution

Shift the `onChange` callback to Downshift's `onStateChange` event handler to ensure that the state reducer will always be run before `onChange` is called.

Additionally, refactor the state reducer to remove the constant declaration for `newInputValue` and shift the calculation to within the return value.

**Bug Fixes**:

- Calls `onChange` with the correct expression value

## Tests

- [ ] Check that replacing `@` -> `@DL1`, then clicking out of the builder field, displays the preview as `DL1` (Standard query replacement)
- [ ] Check that replacing `ABC + @` -> `ABC + DL1`, then clicking out of the builder field, displays the preview as `ABC + DL1` (Standard query replacement with other characters)
- [ ] Check that typing `ABC + DL1` -> `ABC + DL1@`, then clicking out of the builder field, displays the preview as `ABC + DL1@` (No query replacement, adding other characters)
- [ ] Check that any other changes made to the expression input is preserved after clicking out of the builder field (any other edge cases you can think of)