### PR TITLE
feat(navbar): add saved state with tick icon to publish button

### DIFF
--- a/src/client/components/builder/Navbar.tsx
+++ b/src/client/components/builder/Navbar.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { BiArrowBack, BiShow } from 'react-icons/bi'
+import { BiArrowBack, BiCheck, BiShow } from 'react-icons/bi'
 import { getApiErrorMessage } from '../../api'
 import { useHistory, useRouteMatch } from 'react-router-dom'
 import { Redirect } from 'react-router-dom'
@@ -188,12 +188,13 @@ export const Navbar: FC = () => {
         </Link>
         <Button
           variant="outline"
+          leftIcon={!isChanged ? <BiCheck size="24px" /> : undefined}
           colorScheme="primary"
           onClick={handleSave}
           disabled={!isChanged}
           isLoading={save.isLoading}
         >
-          Save Draft
+          {isChanged ? 'Save Draft' : 'Saved'}
         </Button>
         <Button
           variant="solid"


### PR DESCRIPTION
## Problem

Currently, the "Save Draft" button is only disabled when all changes have been applied. This may be ambiguous to the user on whether the checker has been saved or not.

Closes #349 (Note that the spinner on publish was already implemented before this PR)

## Solution

Change this disabled state to more accurately reflect that the changes on the checker have been saved.

**Features**:

- Update "Save Draft" button to read as "Saved" when all pending changes have been applied
- Add tick icon to this "Saved" state

## Before & After Screenshots

**BEFORE**:
Before changes are made:
![Screenshot 2021-05-10 at 3 49 57 PM](https://user-images.githubusercontent.com/21305518/117624985-1f23e400-b1a8-11eb-8998-83563b2cfe7c.png)

After changes are made:
![Screenshot 2021-05-10 at 3 48 44 PM](https://user-images.githubusercontent.com/21305518/117624679-be94a700-b1a7-11eb-82a5-f01cd9c807a4.png)

After saving changes:
![Screenshot 2021-05-10 at 3 49 57 PM](https://user-images.githubusercontent.com/21305518/117624985-1f23e400-b1a8-11eb-8998-83563b2cfe7c.png)

**AFTER**:
Before changes are made:
![Screenshot 2021-05-10 at 3 48 38 PM](https://user-images.githubusercontent.com/21305518/117624673-bd637a00-b1a7-11eb-8e27-91e607647e44.png)

After changes are made:
![Screenshot 2021-05-10 at 3 48 44 PM](https://user-images.githubusercontent.com/21305518/117624679-be94a700-b1a7-11eb-82a5-f01cd9c807a4.png)

After saving changes:
![Screenshot 2021-05-10 at 3 48 38 PM](https://user-images.githubusercontent.com/21305518/117624673-bd637a00-b1a7-11eb-8e27-91e607647e44.png)
