### PR TITLE
fix(otpform): lowercase email before sending otp

### DIFF
--- a/src/client/components/OtpForm.tsx
+++ b/src/client/components/OtpForm.tsx
@@ -28,7 +28,11 @@ export const OtpForm: FC<OtpFormProps> = ({ onSuccess }) => {
   const onSubmit = (data: { email: string }) => {
     sendOtp.reset()
     const { email } = data
-    sendOtp.mutate(email)
+
+    // format email to database expectations
+    const formattedEmail = email.toLowerCase()
+
+    sendOtp.mutate(formattedEmail)
   }
 
   const hasError = () => errors.email || sendOtp.isError

--- a/src/server/auth/AuthService.ts
+++ b/src/server/auth/AuthService.ts
@@ -41,10 +41,15 @@ export class AuthService {
 
   private secretFrom: (email: string) => string = (email) => this.secret + email
 
+  private formatEmail: (email: string) => string = (email) =>
+    email.toLowerCase()
+
   sendOTP: (email: string, ip: string) => Promise<SentMessageInfo> = async (
     email,
     ip
   ) => {
+    email = this.formatEmail(email)
+
     if (!this.emailValidator.match(email)) {
       throw new Error('Invalid email')
     }
@@ -72,6 +77,8 @@ export class AuthService {
     email: string,
     token: string
   ) => Promise<User | undefined> = async (email, token) => {
+    email = this.formatEmail(email)
+
     const isVerified = this.totp.verify({
       secret: this.secretFrom(email),
       token,


### PR DESCRIPTION
## Problem

When someone logs in using email formatted in all capital letters, it doesn't work.

Closes #513

## Solution

Currently, the user model email column and minimatch checks on the domain force emails to be in lowercase. To allow uppercase emails to be used during the sign in procedure, we can lowercase the input strings before passing it to the auth API. 

**Bug Fixes**:

- Format email to lowercase before sending it through to auth APIs.

## Tests

- [ ] Check that logging in works with uppercased / mixed case emails.
