### PR TITLE
fix: set correct active ifelse condition menu item

### DIFF
--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -240,7 +240,7 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
         </HStack>
         {ifelseState.conditions.map((cond, i) => (
           <HStack key={i}>
-            <Menu>
+            <Menu autoSelect={false}>
               {i === 0 ? (
                 <Box w="100px">
                   <MenuButton
@@ -258,13 +258,29 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
                   </Heading>
                 </Box>
               )}
-              <MenuList>
+              <MenuList width="50px">
                 <MenuItem
+                  as={Button}
+                  borderRadius="0"
+                  fontWeight="normal"
+                  textAlign="start"
+                  justifyContent="initial"
+                  height="36px"
+                  isActive={conditionType === ConditionType.And}
+                  variant="ghost"
                   onClick={() => updateAllConditionTypes(ConditionType.And)}
                 >
                   AND
                 </MenuItem>
                 <MenuItem
+                  as={Button}
+                  borderRadius={0}
+                  fontWeight="normal"
+                  textAlign="start"
+                  justifyContent="initial"
+                  height="36px"
+                  isActive={conditionType === ConditionType.Or}
+                  variant="ghost"
                   onClick={() => updateAllConditionTypes(ConditionType.Or)}
                 >
                   OR


### PR DESCRIPTION
Fixes https://github.com/opengovsg/checkfirst/issues/500.

### Currently-selected condition type is set to active
<img width="439" alt="Screenshot 2021-05-11 at 12 25 20 PM" src="https://user-images.githubusercontent.com/19917616/117758137-007b2700-b254-11eb-9338-101edef11d79.png">

### User hovers mouse on non-currently-selected condition type
<img width="499" alt="Screenshot 2021-05-11 at 12 25 25 PM" src="https://user-images.githubusercontent.com/19917616/117758140-02dd8100-b254-11eb-8084-cbac88eb0d17.png">
