### PR TITLE
fix(dropdown-field): fix combobox behaviours to match user expectations

### DIFF
--- a/src/client/components/common/Combobox.tsx
+++ b/src/client/components/common/Combobox.tsx
@@ -197,13 +197,6 @@ export const Combobox: FC<ComboboxProps> = ({
     changes: StateChangeOptions<ComboboxItem>
   ) => {
     switch (changes.type) {
-      case Downshift.stateChangeTypes.clickItem:
-      case Downshift.stateChangeTypes.keyDownEnter:
-      case Downshift.stateChangeTypes.changeInput:
-        // recalculate top search results and scroll back to top of list
-        updateSearchResults(changes.inputValue || '')
-        dropdownListRef.current?.scrollTo(0)
-        break
       case Downshift.stateChangeTypes.blurInput:
       case Downshift.stateChangeTypes.mouseUp:
         // reset inputValue to last valid input value
@@ -237,6 +230,11 @@ export const Combobox: FC<ComboboxProps> = ({
       itemToString={(item) => item?.label || ''}
       onChange={(item) => {
         onChange(`${item ? item.value : ''}`)
+      }}
+      onInputValueChange={(inputValue) => {
+        // recalculate top search results and scroll back to top of list
+        updateSearchResults(inputValue)
+        dropdownListRef.current?.scrollTo(0)
       }}
       defaultHighlightedIndex={0}
     >

--- a/src/client/components/common/Combobox.tsx
+++ b/src/client/components/common/Combobox.tsx
@@ -197,6 +197,8 @@ export const Combobox: FC<ComboboxProps> = ({
     changes: StateChangeOptions<ComboboxItem>
   ) => {
     switch (changes.type) {
+      case Downshift.stateChangeTypes.clickItem:
+      case Downshift.stateChangeTypes.keyDownEnter:
       case Downshift.stateChangeTypes.changeInput:
         // recalculate top search results and scroll back to top of list
         updateSearchResults(changes.inputValue || '')
@@ -208,7 +210,7 @@ export const Combobox: FC<ComboboxProps> = ({
         if (!changes.inputValue) {
           return {
             ...changes,
-            inputValue: state.selectedItem?.label || items[0]?.label || '',
+            inputValue: state.selectedItem?.label || '',
           }
         }
     }
@@ -230,15 +232,11 @@ export const Combobox: FC<ComboboxProps> = ({
 
   return (
     <Downshift
-      initialInputValue={items[0]?.label || ''}
-      initialSelectedItem={items[0] || null}
+      initialHighlightedIndex={0}
       stateReducer={stateReducer}
       itemToString={(item) => item?.label || ''}
       onChange={(item) => {
-        if (item) {
-          onChange(item.value)
-        }
-        inputRef.current?.blur()
+        onChange(`${item ? item.value : ''}`)
       }}
       defaultHighlightedIndex={0}
     >
@@ -272,6 +270,7 @@ export const Combobox: FC<ComboboxProps> = ({
             </label>
             <InputGroup>
               <Input
+                zIndex={100}
                 borderRadius={
                   inputOptions?.useClearButton ? '5px 0px 0px 5px' : '5px'
                 }
@@ -280,12 +279,9 @@ export const Combobox: FC<ComboboxProps> = ({
                 }
                 {...getInputProps({
                   ...props,
+                  placeholder: 'Select an option',
                   ref: inputRef,
                   onFocus: () => {
-                    // reset field for new search
-                    setState({ inputValue: '' })
-                    updateSearchResults('')
-
                     // ensure that menu should be displayed within window bounds
                     setDropdownDir(calculateDropdownDirection())
 
@@ -307,7 +303,11 @@ export const Combobox: FC<ComboboxProps> = ({
                 borderRadius="0px 5px 5px 0px"
                 icon={<BiX size="16px" />}
                 onClick={() => {
-                  // runs input onFocus clear/reset functionality
+                  // reset field for new search
+                  setState({ inputValue: '', selectedItem: null })
+                  updateSearchResults('')
+
+                  // refocus on input field
                   inputRef.current?.focus()
                 }}
               />

--- a/src/client/components/fields/DropdownField.tsx
+++ b/src/client/components/fields/DropdownField.tsx
@@ -25,7 +25,7 @@ export const DropdownField: FC<Field> = ({
       name={id}
       control={control}
       rules={{ required: true }}
-      defaultValue={`${options[0]?.value}`}
+      defaultValue={''}
       // combobox controls its own value independently of the controller
       render={({ ref, onChange }, { invalid }) => (
         <FormControl isInvalid={invalid}>


### PR DESCRIPTION
## Problem

Currently, the combobox selects the first option's value by default. However, this is not good UX as users may inadvertently forget to update the field with their own selection and thus get unexpected results.

Closes #520

## Solution

**Improvements**:

- The default value of dropdown fields are now empty
- Comboboxes display 'Select an option' as a placeholder when no option has been selected
- The combobox clear button now unsets any selected option (if any) on top of clearing the input element
- Focusing on the combobox no longer clears the input element

**Bug Fixes**

- Fixed combobox returning a falsy `0` value instead of a string `'0'` on combobox changes, which affects users if the first option was chosen

## Example

https://user-images.githubusercontent.com/21305518/117758576-e2fa8d00-b254-11eb-83c8-924597fae537.mov

## Tests

- [ ] Check that the combobox behaves as described / shown above
