### PR TITLE
fix: allow selection of title field when there is more than 1 question

### DIFF
--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
+import { noop } from 'lodash'
 import {
   BiHash,
   BiRadioCircleMarked,
@@ -238,7 +239,10 @@ export const QuestionsTab: FC = () => {
   ]
 
   const onSelect = ({ index }: { index: number }) => {
-    setActiveIndex(index)
+    // By default, setActiveIndex would not allow setting active index to -1 unless
+    // it's the last element in items. However, TitleField is a special case and we
+    // want to force an update to -1 index when we are selecting it
+    setActiveIndex(index, index === TITLE_FIELD_INDEX)
   }
 
   const onActive = ({ top }: { top: number }) => {
@@ -283,7 +287,7 @@ export const QuestionsTab: FC = () => {
         onSelect={onSelect}
         onActive={onActive}
         index={TITLE_FIELD_INDEX}
-        setActiveIndex={setActiveIndex}
+        setActiveIndex={noop}
         nextUniqueId={nextUniqueId}
         setNextUniqueId={setNextUniqueId}
       />

--- a/src/client/hooks/use-active-index.ts
+++ b/src/client/hooks/use-active-index.ts
@@ -3,14 +3,15 @@ import { Field, Constant, Operation } from '../../types/checker'
 
 const useActiveIndex = (
   items: Operation[] | Field[] | Constant[]
-): [number, (nextIndex: number) => void] => {
+): [number, (nextIndex: number, force?: boolean) => void] => {
   // Select first item by default if there are 1 or more items.
   const [activeIndex, updateActiveIndex] = useState<number>(() =>
     items.length > 0 ? 0 : -1
   )
 
-  const setActiveIndex = (nextIndex: number) => {
+  const setActiveIndex = (nextIndex: number, force = false) => {
     updateActiveIndex((prevIndex) => {
+      if (force) return nextIndex
       // The only time we want to allow setting activeIndex to -1 is when there are no
       // more items left.
       const isRemoveLastItem =


### PR DESCRIPTION
## Problem
By default `setActiveIndex` only allow setting the index to `-1` if there is only one item in the collection (e.g. when deleting the last item). However, in question tab we make use of `-1` as a special index to represent the TitleField. As such, if there is more than one question, `setActiveIndex` will not set the `activeIndex` to `-1` to select TitleField. 

## Solution

**Bug Fixes**:

- Add a `force` flag to allow explicitly setting of the `activeIndex` to `-1`. Admittedly, this is not a long term fix and we should refactor to clean up the index management for each tab.

## Test
- [ ] Ensure that TitleField can be selected even if there is more than one question
- [ ] Ensure that shift up and shift down are disabled appropriately on the other tabs