### PR TITLE
fix(checker-scroll): fix smooth scrolling for unsupported browsers via polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13137,6 +13137,11 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "scroll-behavior-polyfill": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/scroll-behavior-polyfill/-/scroll-behavior-polyfill-2.0.13.tgz",
+      "integrity": "sha512-X1AC6+k0++Y3XOT8Likr5Dh4XMmwvbTolr3Mp2g1jYPpOQ3++wff/JPfPEK6zqPCkZ88Ac0/OMRW/Uwh16U+HQ=="
+    },
     "seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-router-dom": "^5.2.0",
     "react-window": "^1.8.6",
     "reflect-metadata": "^0.1.13",
+    "scroll-behavior-polyfill": "^2.0.13",
     "sequelize": "^6.6.2",
     "sequelize-typescript": "^2.1.0",
     "serverless-http": "^2.7.0",

--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -25,6 +25,12 @@ import * as checker from './../../types/checker'
 import { evaluate } from './../core/evaluator'
 import { unit, Unit } from 'mathjs'
 import { useGoogleAnalytics } from '../contexts'
+
+// polyfill for browsers that don't support smooth scroling
+if (!('scrollBehavior' in document.documentElement.style)) {
+  import('scroll-behavior-polyfill')
+}
+
 interface CheckerProps {
   config: checker.Checker
 }


### PR DESCRIPTION
## Problem

Smooth scrolling is [not supported](https://caniuse.com/?search=scroll-behavior) on Safari and a number of other browsers.

Closes #434 (Note that standard scrolling already works on Safari, just that it doesn't support `behaviour: smooth`)

## Solution

**Bug Fixes**:

- Dynamically import a smooth scrolling polyfill when the browser does not support smooth scrolling

## Before & After Screenshots

**BEFORE**:

https://user-images.githubusercontent.com/21305518/117952454-c2f7c600-b347-11eb-8260-81c6d4a49d22.mov

**AFTER**:

https://user-images.githubusercontent.com/21305518/117952500-cd19c480-b347-11eb-9e6e-6ba05ed09967.mov

## Tests
- [ ] Check that smooth scrolling works on Safari (or any other browser that does not support smooth scrolling)

## Deploy Notes

**New dependencies**:

- `scroll-behavior-polyfill` : polyfill to provide smooth scrolling behaviour for browsers that do not support said feature.
