### PR TITLE
fix(sentry): provide path to js assets for sourcemaps upload

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = () => {
     jsBundle.plugins.push(
       new SentryCliPlugin({
         // plugin automatically extracts ENV vars: https://docs.sentry.io/product/cli/configuration/
-        include: '.',
+        include: ['build/client'],
         ignoreFile: '.gitignore',
         ignore: ['node_modules', 'webpack.config.js'],
         deploy: {


### PR DESCRIPTION
## Problem

Previously, the correct sourcemaps and their corresponding Javascript files were not uploaded correctly.

Closes #358 

## Solution

**Bug Fixes**:

- Provide path for client in Sentry webpack plugin

## Before & After Screenshots

**Before**
![image](https://user-images.githubusercontent.com/3666479/118582174-7daf1a80-b7c5-11eb-9cb0-d19fd469899c.png)

**After**
![image](https://user-images.githubusercontent.com/3666479/118582137-6c660e00-b7c5-11eb-8050-7668530a0a76.png)


## Test
- [ ] Run deploy on staging and check that the right files were uploaded as artefacts of the release. Navigate to "Settings > checkfirst > checkfirst-frontend > Source maps" and select the latest release.