### PR TITLE
feat: implement dashboard ui with draft/published statuses

### DIFF
--- a/src/client/components/dashboard/CheckerCard.tsx
+++ b/src/client/components/dashboard/CheckerCard.tsx
@@ -4,6 +4,7 @@ import { useQueryClient, useMutation } from 'react-query'
 import { useHistory, useRouteMatch, Link } from 'react-router-dom'
 import { BiDuplicate, BiTrash, BiDotsHorizontalRounded } from 'react-icons/bi'
 import {
+  CSSObject,
   Box,
   useOutsideClick,
   useDisclosure,
@@ -49,6 +50,7 @@ type ActionMenuProps = {
     label: string
     onClick: (e: React.MouseEvent) => void
     icon?: JSX.Element
+    style?: CSSObject
   }>
 }
 
@@ -75,10 +77,11 @@ const ActionMenu: FC<ActionMenuProps> = ({ actions }) => {
           Click
         </MenuButton>
         <MenuList>
-          {actions.map(({ onClick, icon, label }, i) => (
+          {actions.map(({ onClick, label, icon, style }, i) => (
             <MenuItem
               key={i}
               icon={icon}
+              sx={style}
               onClick={(e) => {
                 e.preventDefault()
                 onClose()
@@ -130,7 +133,12 @@ export const CheckerCard: FC<CheckerCardProps> = ({ checker }) => {
 
   const actions = [
     { label: 'Duplicate', icon: <BiDuplicate />, onClick: onDuplicateClick },
-    { label: 'Delete', icon: <BiTrash />, onClick: onDelete },
+    {
+      label: 'Delete',
+      icon: <BiTrash />,
+      onClick: onDelete,
+      style: { color: '#FB5D64' },
+    },
   ]
 
   return (

--- a/src/client/components/dashboard/CreateNewCard.tsx
+++ b/src/client/components/dashboard/CreateNewCard.tsx
@@ -10,10 +10,12 @@ export const CreateNewCard: FC = () => {
   return (
     <>
       <Link to={{ pathname: `${path}/create` }}>
-        <VStack sx={styles.card}>
+        <VStack sx={styles.card} spacing="26px">
           <BiPlus size="50px" style={{ display: 'inline' }} />
           <Text mt="16px" sx={styles.title}>
-            Create New
+            Create new
+            <br />
+            checker
           </Text>
         </VStack>
       </Link>

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -88,7 +88,7 @@ export const Dashboard: FC = () => {
               ) : (
                 <>
                   {checkers && checkers.length > 0 ? (
-                    <SimpleGrid columns={5} spacing={8}>
+                    <SimpleGrid columns={4} spacing="32px">
                       <CreateNewCard />
                       {checkers?.map((checker) => {
                         return (

--- a/src/client/theme/components/CheckerCard.tsx
+++ b/src/client/theme/components/CheckerCard.tsx
@@ -2,30 +2,36 @@ export const CheckerCard = {
   parts: ['card', 'title', 'actions'],
   baseStyle: {
     card: {
-      h: '160px',
-      maxW: '160px',
-      textAlign: 'center',
+      h: '200px',
       justifyContent: 'space-between',
       boxShadow: 'md',
-      borderRadius: '12px',
+      borderRadius: '3px',
       bg: 'white',
-      p: 8,
+      p: '24px',
     },
     title: {
       fontSize: '16px',
-      fontWeight: '600',
+      fontWeight: '500',
+      lineHeight: '24px',
+      letterSpacing: '-0.011em',
     },
     subtitle: {
-      fontSize: '14px',
-      fontWeight: '500',
-      color: '#767676',
+      fontSize: '12px',
+      fontWeight: '400',
+      lineHeight: '16px',
+      color: '#A5ABB3',
     },
     actions: {
-      visibility: 'hidden',
-      justifyContent: 'center',
-      _groupHover: {
-        visibility: 'visible',
-      },
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    indicator: {
+      fontSize: '12px',
+      lineHeight: '16px',
+      fontWeight: '400',
+      color: '#2C3A4B',
+      textTransform: 'capitalize',
+      alignItems: 'center',
     },
   },
   variants: {
@@ -33,6 +39,8 @@ export const CheckerCard = {
       card: {
         bg: 'primary.500',
         color: 'white',
+        textAlign: 'center',
+        justifyContent: 'center',
       },
       title: {
         mt: '16px',

--- a/src/server/checker/CheckerService.ts
+++ b/src/server/checker/CheckerService.ts
@@ -70,6 +70,10 @@ export class CheckerService {
           model: this.UserModel,
           where: { id: user.id },
         },
+        {
+          model: this.PublishedCheckerModel,
+          attributes: ['id', 'createdAt'],
+        },
       ],
       order: [['updatedAt', 'DESC']],
     })

--- a/src/types/checker.d.ts
+++ b/src/types/checker.d.ts
@@ -28,6 +28,7 @@ export type DashboardCheckerDTO = Pick<
   | 'operations'
   | 'displays'
   | 'updatedAt'
+  | 'publishedCheckers'
 >
 
 export type CreatePublishedCheckerDTO = Pick<


### PR DESCRIPTION
## Problem

Currently there is no indicator on the dashboard on whether a checker is published or still a draft.

## Solution

**Features**:

- Implement updated dashboard design with indicators for published and draft

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/3666479/118632773-55461100-b803-11eb-9e9a-3c16502955d1.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/3666479/118633310-ea490a00-b803-11eb-9532-77b5fe3822a9.png)

## Tests
- [x] Creation of checker works as expected
- [x] Duplication of checker works as expected
- [x] Deletion of checker works as expected
- [x] Create a new checker and observe that the indicator shows a draft state on the dashboard
- [x] Create and publish a new checker and observe that the indicator shows a published state on the dashboard