### PR TITLE
refactor(expression-input): make downshift controlled

### DIFF
--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -233,6 +233,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
               const end = e.currentTarget.selectionEnd || 0
               setSelection({ start: start, end: end })
             }}
+            onBlur={() => setSelection({ start: -1, end: -1 })}
           />
           <UnorderedList
             {...getMenuProps()}


### PR DESCRIPTION
## Problem

Currently, Downshift maintains an internal state that includes data such as the `inputValue` and `isOpen`. In most use cases, this is sufficient for a basic implementation. However, these states become hard to manipulate through recommended means (such as the state reducer) when implementing highly customized dropdowns, as seen in the query replacement feature.

Additionally, there is confusion over when internal states are updated with new values, which may lead to unexpected behaviour over time.

Finally, there are accessibility issues pertaining to the optional rendering and subsequent calling of `getMenuProps`, which is advised against in the Downshift documentation.

## Solution

To mitigate the issues with using an obscured internal state, we can override these internal Downshift state with our own, effectively creating a Single Source Of Truth (SSOT) state.

This also opens up better avenues of ensuring that data is synchronized with the checker context.

> Note that we still update Downshift's internal states in this solution instead of avoiding them. This is to ensure that Downshift's accessibility features will still work according to the updated state values.

**Features**

- Shift caret tracking code to `onSelect`. This should allow users to update their cursor position, and by extension, the currently edited query block by using the left or right arrow keys or clicking

**Improvements**:

- Implement SSOT states for `inputValue`
- Re-implement `isOpen` as a calculated value (refer to note for more details). This also shifts the `baseSort` helper function closer to where its used for easier comprehension.
- Use unconditional rendering of `UnorderedList` to always call `getMenuProps` as recommended by Downshift. 
- Shift `useChange` callback prop update calls into a `useEffect` hook to guarantee state consistency with the checker context
- Implement another `useEffect` hook to sync `inputValue` with subsequent `value` prop updates after state initialisation
- Use internal state to get and set input string selection to stop `setSelectedRange` calls from being reset on re-renders.
- Reduce dependency on Downshift `getInputProp` prop getter to prepare for possible textarea implementation.

**Bug Fixes**:

- Fix type of `value` input prop to use `string` instead of Chakra's own value types to better mirror how the component uses the prop / is being given the prop.

## Tests

- [x] Check basic input field functionality
  - [x] Check that replacing `@` -> `@DL1`, then clicking out of the builder field, displays the preview as `DL1` (Standard query replacement)
  - [x] Check that replacing `ABC + @` -> `ABC + DL1`, then clicking out of the builder field, displays the preview as `ABC + DL1` (Standard query replacement with other characters)
  - [x] Check that typing `ABC + DL1` -> `ABC + DL1@`, then clicking out of the builder field, displays the preview as `ABC + DL1@` (No query replacement, adding other characters)
  - [x] Check that any other changes made to the expression input is preserved after clicking out of the builder field (any other edge cases you can think of)
- [x] Check that shifting the cursor from `@ + ABC|` -> `@| + ABC` opens the query replacement menu, and vice versa.
- [x] Check that clicking out from the input field (e.g `@| + ABC` -> `@ + ABC`) hides the query replacement menu