### PR TITLE
fix(expression-input): clear selection on click out of component

### DIFF
--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -52,20 +52,20 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
   ...props
 }) => {
   const [inputValue, setInputValue] = useState<string>(value)
-  const [showCalcBar, setShowCalcBar] = useState(false)
+  const [hasFocus, setHasFocus] = useState(false)
   const [selection, setSelection] = useState<{ start: number; end: number }>()
 
   const inputRef = useRef<HTMLInputElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
 
-  // hide calc bar when clicking outside of the component
+  // hide calc bar and reset selection when clicking outside of the component
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
         wrapperRef.current &&
         !wrapperRef.current.contains(event.target as Node)
       ) {
-        setShowCalcBar(false)
+        setHasFocus(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
@@ -223,7 +223,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
       }
     })
     inputRef.current?.focus()
-    setShowCalcBar(true)
+    setHasFocus(true)
   }
 
   const currentMatches = getCurrentQueryMatches()
@@ -233,7 +233,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
       <Downshift
         // controlled values
         inputValue={inputValue}
-        isOpen={!!currentMatches}
+        isOpen={!!currentMatches && hasFocus}
         // item aria-label converter
         itemToString={(item) => item?.id || ''}
         // default values
@@ -274,7 +274,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
                 const end = e.currentTarget.selectionEnd || 0
                 setSelection({ start: start, end: end })
               }}
-              onFocus={() => setShowCalcBar(true)}
+              onFocus={() => setHasFocus(true)}
             />
             <UnorderedList
               {...getMenuProps()}
@@ -315,7 +315,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
           </VStack>
         )}
       </Downshift>
-      {showCalcBar ? (
+      {hasFocus ? (
         <CalculatorBar
           minH="48px"
           backgroundColor="#F4F6F9"


### PR DESCRIPTION
## Problem

The query replacement dropdown is not hidden when the user clicks out of the expression input component, which is unexpected behaviour.

## Solution

Consolidate the focus state used to hide and show the calculator bar along with the query replacement dropdown toggle, such that the dropdown is only shown when the expression input is focused and a valid query block is selected.

**Bug Fixes**:

- Renamed `showCalcBar` state to `hasFocus`, which better represents the state's meaning
- Updated logic for Downshift `isOpen` controlled state.

## Tests

- [ ] Check basic input field functionality
  - [ ] Check that replacing `@` -> `@DL1`, then clicking out of the builder field, displays the preview as `DL1` (Standard query replacement)
  - [ ] Check that replacing `ABC + @` -> `ABC + DL1`, then clicking out of the builder field, displays the preview as `ABC + DL1` (Standard query replacement with other characters)
  - [ ] Check that typing `ABC + DL1` -> `ABC + DL1@`, then clicking out of the builder field, displays the preview as `ABC + DL1@` (No query replacement, adding other characters)
  - [ ] Check that any other changes made to the expression input is preserved after clicking out of the builder field (any other edge cases you can think of)
- [ ] Check that shifting the cursor from `@ + ABC|` -> `@| + ABC` opens the query replacement menu, and vice versa.
- [ ] Check that clicking out from the input field (e.g `@| + ABC` -> `@ + ABC`) hides the query replacement menu
