### PR TITLE
fix(frontend): parsing of conditional expressions with `and` or `or`

### DIFF
--- a/src/client/core/__test__/parser.spec.ts
+++ b/src/client/core/__test__/parser.spec.ts
@@ -1,0 +1,57 @@
+import { parseConditionalExpr } from '../parser'
+
+describe('parseConditional', () => {
+  it('should parse expression with only one condition', () => {
+    const expr = 'ifelse(R1 == "Option A", true, false)'
+    const parsed = parseConditionalExpr(expr)
+
+    expect(parsed).toMatchObject({
+      ifExpr: 'R1 == "Option A"',
+      conditions: [],
+      thenExpr: 'true',
+      elseExpr: 'false',
+    })
+  })
+
+  it('should parse expression with multiple conditions', () => {
+    const expr = 'ifelse(R1 == "A" or (R2 == 2) or (R3 == "C"), true, false)'
+    const parsed = parseConditionalExpr(expr)
+
+    expect(parsed).toMatchObject({
+      ifExpr: 'R1 == "A"',
+      conditions: [
+        { expression: 'R2 == 2', type: 'OR' },
+        { expression: 'R3 == "C"', type: 'OR' },
+      ],
+      thenExpr: 'true',
+      elseExpr: 'false',
+    })
+  })
+
+  it('should parse expression with and/or in quoted values', () => {
+    const expr = `ifelse(R1 == "A or B" or (R2 == max(1, 2)) and (R3 == "E and F"), true, false)`
+    const parsed = parseConditionalExpr(expr)
+
+    expect(parsed).toMatchObject({
+      ifExpr: `R1 == "A or B"`,
+      conditions: [
+        { expression: 'R2 == max(1, 2)', type: 'OR' },
+        { expression: 'R3 == "E and F"', type: 'AND' },
+      ],
+      thenExpr: 'true',
+      elseExpr: 'false',
+    })
+  })
+
+  it('should parse expression with parentheses in quoted values', () => {
+    const expr = `ifelse(R1 == "A (Singaporean or PR)" or (R2 == "B (Foreign Residents)"), true, false)`
+    const parsed = parseConditionalExpr(expr)
+
+    expect(parsed).toMatchObject({
+      ifExpr: `R1 == "A (Singaporean or PR)"`,
+      conditions: [{ expression: 'R2 == "B (Foreign Residents)"', type: 'OR' }],
+      thenExpr: 'true',
+      elseExpr: 'false',
+    })
+  })
+})

--- a/src/client/core/parser.ts
+++ b/src/client/core/parser.ts
@@ -1,0 +1,61 @@
+import * as mathjs from 'mathjs'
+import { math } from './evaluator'
+import { Condition, IfelseState } from '../../types/conditional'
+
+/**
+ * Parse conditional expression into separate parts
+ * @param expression ifelse expression string
+ */
+export const parseConditionalExpr = (expression: string): IfelseState => {
+  const root = math.parse!(expression)
+  const { name, args } = root
+
+  // Parsing is only support for expression in the form of ifelse(CONDITION, THEN, ELSE)
+  if (name !== 'ifelse') throw new Error('Not ifelse expression')
+  if (args?.length !== 3)
+    throw new Error('Invalid number of args for ifelse expression')
+
+  const [conditionNode, thenNode, elseNode] = args
+  const thenExpr = thenNode.toString().trim()
+  const elseExpr = elseNode.toString().trim()
+
+  /*
+    Do a depth-first traversal of the mathjs expression tree to parse conditional expression.
+    For example, parsing`A == 1 or (B == 2) or (C == 3)` will create the following tree:
+              or
+             /  \
+            or   C == 3
+           /  \
+      A == 1  B == 2
+  */
+  const dfs = (node: mathjs.MathNode, conds: string[], ops: string[]) => {
+    const { op, args } = node
+    if (op !== 'and' && op !== 'or') return conds.push(node.toString())
+    if (!args || args.length !== 2) return
+
+    const [left, right] = args
+    ops.push(op)
+    dfs(left, conds, ops)
+    dfs(right, conds, ops)
+  }
+
+  const conds: string[] = []
+  const ops: string[] = []
+  dfs(conditionNode, conds, ops)
+
+  const conditions: Condition[] = conds.slice(1).map((c, i) => {
+    const expression =
+      c[0] === '(' && c[c.length - 1] === ')' ? c.substring(1, c.length - 1) : c
+    return {
+      expression: expression.trim(),
+      type: ops[i] === 'or' ? 'OR' : 'AND',
+    }
+  })
+
+  return {
+    ifExpr: conds[0].trim(),
+    conditions,
+    thenExpr,
+    elseExpr,
+  }
+}

--- a/src/types/conditional.d.ts
+++ b/src/types/conditional.d.ts
@@ -1,0 +1,13 @@
+export type ConditionType = 'AND' | 'OR'
+
+export interface Condition {
+  type: ConditionType
+  expression: string
+}
+
+export interface IfelseState {
+  ifExpr: string
+  conditions: Condition[]
+  elseExpr: string
+  thenExpr: string
+}


### PR DESCRIPTION
## Problem

Closes #630 

## Solution

**Improvements**:
- Parse conditional expression to `IfelseState` using `mathjs` expression tree instead of regex
- Add test coverage for parsing to prevent regressions

**Bug fixes**
- Fix parsing for expression that includes `and` or `or`.
- Fix parsing for expression that includes parentheses. E.g. `R1 == "A (B)`.

## Tests
- [ ] Create a conditional input and insert an expression that compares against value that contains `and` or `or`. E.g. `R1 == "Singaporean or PR"`. The application should not crash.
- [ ] - [ ] Create a conditional input and insert an expression that compares against value that contains parentheses. E.g. `R1 == "A (B)"`. Clicking out and then back in to the block. The expression should be displayed correctly.
