### PR TITLE
feat(builder-field): align with design system and introduce dynamic colour highlights

### DIFF
--- a/src/client/components/builder/ActionButton.tsx
+++ b/src/client/components/builder/ActionButton.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from 'react'
-import { IconButtonProps, useStyles, IconButton } from '@chakra-ui/react'
+import { IconButtonProps, IconButton, useStyleConfig } from '@chakra-ui/react'
 
 export const ActionButton: FC<IconButtonProps> = (props) => {
-  const styles = useStyles()
-  return <IconButton {...props} variant="link" sx={styles.action} />
+  const { colorScheme, ...rest } = props
+  const styles = useStyleConfig('ActionButton', { colorScheme })
+  return <IconButton {...rest} variant="ghost" sx={styles} />
 }

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -102,7 +102,16 @@ export const createBuilderField =
     const [ref, { top }] = usePosition()
     const { dispatch } = useCheckerContext()
     const variant = active ? 'active' : ''
-    const styles = useMultiStyleConfig('BuilderField', { variant })
+    const colorScheme = !active
+      ? 'inactive'
+      : isFieldData(data) || isTitleData(data)
+      ? 'success'
+      : isConstantData(data)
+      ? 'warning'
+      : isOperationData(data)
+      ? 'primary'
+      : 'primary' // fallback
+    const styles = useMultiStyleConfig('BuilderField', { variant, colorScheme })
 
     useEffect(() => {
       if (active) onActive({ top })
@@ -240,7 +249,7 @@ export const createBuilderField =
           {(isFieldData(data) ||
             isOperationData(data) ||
             isConstantData(data)) && (
-            <Button colorScheme="primary" sx={styles.badge}>
+            <Button colorScheme={colorScheme} sx={styles.badge}>
               {data.id}
             </Button>
           )}

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -102,15 +102,15 @@ export const createBuilderField =
     const [ref, { top }] = usePosition()
     const { dispatch } = useCheckerContext()
     const variant = active ? 'active' : ''
-    const colorScheme = !active
-      ? 'inactive'
-      : isFieldData(data) || isTitleData(data)
-      ? 'success'
-      : isConstantData(data)
-      ? 'warning'
-      : isOperationData(data)
-      ? 'primary'
-      : 'primary' // fallback
+
+    const getVariant = (data: BuilderFieldData): string => {
+      if (!active) return 'inactive'
+      if (isFieldData(data) || isTitleData(data)) return 'success'
+      if (isConstantData(data)) return 'warning'
+      if (isOperationData(data)) return 'primary'
+      return 'primary'
+    }
+    const colorScheme = getVariant(data)
     const styles = useMultiStyleConfig('BuilderField', { variant, colorScheme })
 
     useEffect(() => {

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -254,8 +254,11 @@ export const createBuilderField =
             </Button>
           )}
           <Flex sx={styles.content}>{renderContent()}</Flex>
-          {active && !isTitleData(data) && (
-            <HStack sx={styles.actionBar} spacing={0}>
+          {active && (
+            <HStack
+              sx={isTitleData(data) ? styles.barSpacer : styles.actionBar}
+              spacing={0}
+            >
               {isOperationData(data) && (
                 <ActionButton
                   aria-label="Duplicate"

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -254,8 +254,8 @@ export const createBuilderField =
             </Button>
           )}
           <Flex sx={styles.content}>{renderContent()}</Flex>
-          {active && (
-            <HStack justifyContent="flex-end">
+          {active && !isTitleData(data) && (
+            <HStack sx={styles.actionBar} spacing={0}>
               {isOperationData(data) && (
                 <ActionButton
                   aria-label="Duplicate"

--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -291,6 +291,7 @@ export const createBuilderField =
                     onClick={handleDuplicate}
                   />
                   <ActionButton
+                    colorScheme="error"
                     aria-label="Delete"
                     icon={
                       <DefaultTooltip label="Delete">

--- a/src/client/theme/components/builder/ActionButton.tsx
+++ b/src/client/theme/components/builder/ActionButton.tsx
@@ -1,0 +1,9 @@
+import { ComponentSingleStyleConfig } from '@chakra-ui/theme'
+
+export const ActionButton: ComponentSingleStyleConfig = {
+  baseStyle: ({ colorScheme }) => ({
+    color: `${colorScheme}.500`,
+    fontSize: '16px',
+    borderRadius: '3px',
+  }),
+}

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -19,6 +19,7 @@ export const BuilderField: ComponentMultiStyleConfig = {
     'content',
     'badge',
     'actionBar',
+    'barSpacer',
     ...CommonComponents.parts,
   ],
   baseStyle: {
@@ -48,6 +49,9 @@ export const BuilderField: ComponentMultiStyleConfig = {
       borderTop: 'solid 1px',
       borderTopColor: 'secondary.200',
       justifyContent: 'flex-end',
+    },
+    barSpacer: {
+      h: 2,
     },
     ...CommonComponents.baseStyle,
   },

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -14,11 +14,16 @@ const CommonComponents: ComponentMultiStyleConfig = {
 }
 
 export const BuilderField: ComponentMultiStyleConfig = {
-  parts: ['container', 'action', 'content', 'badge', ...CommonComponents.parts],
+  parts: [
+    'container',
+    'action',
+    'content',
+    'badge',
+    'actionBar',
+    ...CommonComponents.parts,
+  ],
   baseStyle: {
     container: {
-      py: 8,
-      px: 4,
       w: '100%',
       bg: 'white',
       borderRadius: '3px',
@@ -32,6 +37,9 @@ export const BuilderField: ComponentMultiStyleConfig = {
         color: 'primary.300',
       },
     },
+    content: {
+      p: 8,
+    },
     badge: {
       w: '40px',
       h: '40px',
@@ -41,6 +49,13 @@ export const BuilderField: ComponentMultiStyleConfig = {
       zIndex: 9,
       transition: 'none',
       color: 'neutral.800',
+    },
+    actionBar: {
+      h: 12,
+      px: 4,
+      borderTop: 'solid 1px',
+      borderTopColor: 'secondary.200',
+      justifyContent: 'flex-end',
     },
     ...CommonComponents.baseStyle,
   },
@@ -57,7 +72,8 @@ export const BuilderField: ComponentMultiStyleConfig = {
         color: 'white',
       },
       content: {
-        mb: 6,
+        pl: 6,
+        pb: 6,
       },
     }),
   },

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -1,4 +1,6 @@
-const CommonComponents = {
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+const CommonComponents: ComponentMultiStyleConfig = {
   parts: ['dummyInput'],
   baseStyle: {
     dummyInput: {
@@ -11,7 +13,7 @@ const CommonComponents = {
   },
 }
 
-export const BuilderField = {
+export const BuilderField: ComponentMultiStyleConfig = {
   parts: ['container', 'action', 'content', 'badge', ...CommonComponents.parts],
   baseStyle: {
     container: {
@@ -19,7 +21,7 @@ export const BuilderField = {
       px: 4,
       w: '100%',
       bg: 'white',
-      borderRadius: '12px',
+      borderRadius: '3px',
       cursor: 'pointer',
       position: 'relative',
     },
@@ -38,23 +40,25 @@ export const BuilderField = {
       left: `-${40 + 16}px`,
       zIndex: 9,
       transition: 'none',
+      color: 'neutral.800',
     },
     ...CommonComponents.baseStyle,
   },
   variants: {
-    active: {
+    active: ({ colorScheme }) => ({
       container: {
-        borderLeft: 'solid 12px',
-        borderLeftColor: 'primary.500',
+        borderLeft: 'solid 8px',
+        borderLeftColor: `${colorScheme}.500`,
         boxShadow: '0px 0px 10px #DADEE3',
         cursor: 'auto',
       },
       badge: {
-        left: `-${40 + 12 + 16}px`, // Add 12px for left border
+        left: `-${40 + 8 + 16}px`, // Add 8px for left border
+        color: 'white',
       },
       content: {
         mb: 6,
       },
-    },
+    }),
   },
 }

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -16,7 +16,6 @@ const CommonComponents: ComponentMultiStyleConfig = {
 export const BuilderField: ComponentMultiStyleConfig = {
   parts: [
     'container',
-    'action',
     'content',
     'badge',
     'actionBar',
@@ -29,13 +28,6 @@ export const BuilderField: ComponentMultiStyleConfig = {
       borderRadius: '3px',
       cursor: 'pointer',
       position: 'relative',
-    },
-    action: {
-      color: 'secondary.500',
-      fontSize: '20px',
-      _hover: {
-        color: 'primary.300',
-      },
     },
     content: {
       p: 8,

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -1,5 +1,18 @@
+const CommonComponents = {
+  parts: ['dummyInput'],
+  baseStyle: {
+    dummyInput: {
+      bg: 'neutral.200',
+      _disabled: {
+        opacity: 1.0,
+        cursor: 'not-allowed',
+      },
+    },
+  },
+}
+
 export const BuilderField = {
-  parts: ['container', 'action', 'dummyInput', 'content', 'badge'],
+  parts: ['container', 'action', 'content', 'badge', ...CommonComponents.parts],
   baseStyle: {
     container: {
       py: 8,
@@ -17,13 +30,6 @@ export const BuilderField = {
         color: 'primary.300',
       },
     },
-    dummyInput: {
-      bg: 'neutral.200',
-      _disabled: {
-        opacity: 1.0,
-        cursor: 'not-allowed',
-      },
-    },
     badge: {
       w: '40px',
       h: '40px',
@@ -33,6 +39,7 @@ export const BuilderField = {
       zIndex: 9,
       transition: 'none',
     },
+    ...CommonComponents.baseStyle,
   },
   variants: {
     active: {

--- a/src/client/theme/components/builder/index.ts
+++ b/src/client/theme/components/builder/index.ts
@@ -1,0 +1,5 @@
+import { BuilderField } from './BuilderField'
+
+export const builder = {
+  BuilderField,
+}

--- a/src/client/theme/components/builder/index.ts
+++ b/src/client/theme/components/builder/index.ts
@@ -1,5 +1,7 @@
 import { BuilderField } from './BuilderField'
+import { ActionButton } from './ActionButton'
 
 export const builder = {
   BuilderField,
+  ActionButton,
 }

--- a/src/client/theme/components/index.ts
+++ b/src/client/theme/components/index.ts
@@ -1,11 +1,11 @@
-import { BuilderField } from './BuilderField'
+import { builder } from './builder'
 import { FloatingToolbar } from './FloatingToolbar'
 import { CheckerCard } from './CheckerCard'
 import { Checker } from './Checker'
 import { LineDisplay } from './LineDisplay'
 
 export const components = {
-  BuilderField,
+  ...builder,
   FloatingToolbar,
   CheckerCard,
   Checker,

--- a/src/client/theme/foundations/colors.ts
+++ b/src/client/theme/foundations/colors.ts
@@ -122,4 +122,9 @@ export const colors = {
     100: '#EDEDED',
     50: '#F9F9F9',
   },
+  inactive: {
+    500: '#FBFCFD',
+    600: '#EEEEEE',
+    700: '#DADEE3',
+  },
 }


### PR DESCRIPTION
## Problem

Updates the `BuilderField` component to align with the new design system.

Part of #549

## Solution

**Features**:

- Border highlight colours change depending on the builder field's type

**Improvements**:

- Organize builder styles into its own individual folder
- Declare types for builder styles
- Implement `colorScheme` support for builder field components
- Refactored `ActionButton` styles as a separate component style
- Separate common field component styles such as `dummyInput` away from the main builder field component styles for clarity
- Aligned builder field layout and styles with design system

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-06-03 at 4 32 26 PM](https://user-images.githubusercontent.com/21305518/120613948-4dd06a00-c489-11eb-9a1a-8313e6479ecc.png)

**AFTER**:
![Screenshot 2021-06-03 at 4 31 36 PM](https://user-images.githubusercontent.com/21305518/120613982-5759d200-c489-11eb-8f21-e35e17ae6c59.png)

## Tests

- [ ] Check that dynamic color highlighting works as per design system (question tab - teal/green, constants tab - yellow, logic tab - dark blue)
- [ ] Verify that the new layout aligns with the design system (excluding input component/ preview components)
