### PR TITLE
feat(question-fields): align with design system and implement textarea for description inputs

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useRef, useLayoutEffect } from 'react'
+import React, { FC, useState, useRef } from 'react'
 import { isEmpty, filter } from 'lodash'
 import {
   useToast,
@@ -48,19 +48,6 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
   const [variables, setVariables] = useState<checker.VariableResults>({})
   const googleAnalytics = useGoogleAnalytics()
   const outcomes = useRef<HTMLDivElement | null>(null)
-
-  // conditionally toggle description label between center align (1 line) and left align (> 1 line)
-  const descriptionRef = useRef<HTMLParagraphElement>(null)
-  useLayoutEffect(() => {
-    if (descriptionRef.current && styles.subtitle.lineHeight) {
-      const height = descriptionRef.current.clientHeight
-      const singleLineHeight = parseInt(
-        styles.subtitle.lineHeight.toString().slice(0, -2), // slice removes 'px' suffix
-        10
-      )
-      if (height > singleLineHeight) descriptionRef.current.style.width = '100%'
-    }
-  }, [descriptionRef, description, styles.subtitle.lineHeight])
 
   const renderField = (field: checker.Field, i: number) => {
     switch (field.type) {
@@ -174,11 +161,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
             <VStack align="stretch" spacing={10}>
               <VStack spacing={2}>
                 <Text sx={styles.title}>{title}</Text>
-                {description && (
-                  <Text sx={styles.subtitle} ref={descriptionRef}>
-                    {description}
-                  </Text>
-                )}
+                {description && <Text sx={styles.subtitle}>{description}</Text>}
               </VStack>
               {fields.map(renderField)}
               <Button colorScheme="primary" width="100%" type="submit">

--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useRef } from 'react'
+import React, { FC, useState, useRef, useLayoutEffect } from 'react'
 import { isEmpty, filter } from 'lodash'
 import {
   useToast,
@@ -48,6 +48,19 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
   const [variables, setVariables] = useState<checker.VariableResults>({})
   const googleAnalytics = useGoogleAnalytics()
   const outcomes = useRef<HTMLDivElement | null>(null)
+
+  // conditionally toggle description label between center align (1 line) and left align (> 1 line)
+  const descriptionRef = useRef<HTMLParagraphElement>(null)
+  useLayoutEffect(() => {
+    if (descriptionRef.current && styles.subtitle.lineHeight) {
+      const height = descriptionRef.current.clientHeight
+      const singleLineHeight = parseInt(
+        styles.subtitle.lineHeight.toString().slice(0, -2), // slice removes 'px' suffix
+        10
+      )
+      if (height > singleLineHeight) descriptionRef.current.style.width = '100%'
+    }
+  }, [descriptionRef, description, styles.subtitle.lineHeight])
 
   const renderField = (field: checker.Field, i: number) => {
     switch (field.type) {
@@ -161,7 +174,11 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
             <VStack align="stretch" spacing={10}>
               <VStack spacing={2}>
                 <Text sx={styles.title}>{title}</Text>
-                {description && <Text sx={styles.subtitle}>{description}</Text>}
+                {description && (
+                  <Text sx={styles.subtitle} ref={descriptionRef}>
+                    {description}
+                  </Text>
+                )}
               </VStack>
               {fields.map(renderField)}
               <Button colorScheme="primary" width="100%" type="submit">

--- a/src/client/components/builder/questions/CheckboxField.tsx
+++ b/src/client/components/builder/questions/CheckboxField.tsx
@@ -1,15 +1,20 @@
 import React from 'react'
-import { BiListCheck, BiX } from 'react-icons/bi'
+import { BiPlus, BiSelectMultiple, BiTrash } from 'react-icons/bi'
 import {
   Button,
   IconButton,
-  Box,
   HStack,
   VStack,
   Text,
   Input,
   Checkbox,
   CheckboxGroup,
+  useStyles,
+  InputGroup,
+  InputLeftElement,
+  useMultiStyleConfig,
+  Icon,
+  Flex,
 } from '@chakra-ui/react'
 
 import * as checker from '../../../../types/checker'
@@ -17,9 +22,13 @@ import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { useCheckerContext } from '../../../contexts'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 
+import '../../../styles/big-checkbox.css'
+
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
   const { dispatch } = useCheckerContext()
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('CheckboxField', {})
 
   const updateTitleOrDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -80,8 +89,8 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
 
   const renderOption = (option: checker.FieldOption, i: number) => {
     return (
-      <HStack key={i}>
-        <Checkbox isChecked={false} />
+      <HStack key={i} spacing={4}>
+        <Checkbox sx={styles.checkbox} isChecked={false} />
         <Input
           type="text"
           value={option.label}
@@ -90,9 +99,11 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
           }}
         />
         <IconButton
+          sx={styles.deleteOptionButton}
+          colorScheme="error"
           aria-label="Delete option"
-          fontSize="20px"
-          icon={<BiX />}
+          variant="link"
+          icon={<BiTrash />}
           disabled={field.options.length <= 1}
           onClick={() => deleteOption(option, i)}
         />
@@ -101,60 +112,75 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiListCheck />
-      </Box>
-      <VStack align="stretch" w="90%" spacing={6}>
-        <VStack align="stretch" spacing={2}>
-          <Input
-            type="text"
-            name="title"
-            placeholder="Question"
-            onChange={updateTitleOrDescription}
-            value={title}
-          />
-          <Input
-            type="text"
-            name="description"
-            placeholder="Description"
-            onChange={updateTitleOrDescription}
-            value={description}
-          />
-        </VStack>
-        <VStack spacing={4} alignItems="left" w="50%">
-          {field.options.map(renderOption)}
-          <HStack h={10}>
-            <Checkbox isChecked={false} />
-            <Box pl={2}>
-              <Button variant="link" onClick={addOption}>
-                Add new option
-              </Button>
-            </Box>
-          </HStack>
-        </VStack>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiSelectMultiple />}
+        />
+        <Input
+          type="text"
+          sx={commonStyles.fieldInput}
+          name="title"
+          placeholder="Question"
+          onChange={updateTitleOrDescription}
+          value={title}
+        />
+      </InputGroup>
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name="description"
+        placeholder="Description"
+        onChange={updateTitleOrDescription}
+        value={description}
+      />
+      <VStack sx={commonStyles.halfWidthContainer} spacing={4}>
+        {field.options.map(renderOption)}
+        <HStack sx={styles.addOptionContainer} spacing={4}>
+          <Icon as={BiPlus} sx={styles.addOptionIcon} />
+          <Button
+            variant="link"
+            sx={styles.addOptionButton}
+            onClick={addOption}
+          >
+            Add option
+          </Button>
+        </HStack>
       </VStack>
-    </HStack>
+    </VStack>
   )
 }
 
 const PreviewComponent: QuestionFieldComponent = ({ field }) => {
   const { title, description, options } = field
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('CheckboxField', {})
+
   return (
-    <VStack align="stretch" w="100%" spacing={6}>
-      <VStack align="stretch">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={2}>
+      <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiListCheck fontSize="20px" />
-          <Text>{title}</Text>
+          <BiSelectMultiple fontSize="20px" />
+          <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
-        {description && <Text color="secondary.400">{description}</Text>}
+        {description && (
+          <Text sx={commonStyles.previewDescription}>{description}</Text>
+        )}
       </VStack>
       <CheckboxGroup>
-        <VStack alignItems="left" spacing={2}>
+        <VStack sx={styles.previewOptionsContainer} spacing={0}>
           {options.map(({ value, label }, i) => (
-            <Checkbox key={i} value={value} isChecked={false}>
-              {label}
-            </Checkbox>
+            <Flex key={i} sx={styles.previewOptionRowContainer}>
+              <Checkbox
+                sx={styles.checkbox}
+                spacing={4}
+                value={value}
+                isChecked={false}
+              >
+                <Text sx={styles.checkboxText}>{label}</Text>
+              </Checkbox>
+            </Flex>
           ))}
         </VStack>
       </CheckboxGroup>

--- a/src/client/components/builder/questions/CheckboxField.tsx
+++ b/src/client/components/builder/questions/CheckboxField.tsx
@@ -90,7 +90,11 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const renderOption = (option: checker.FieldOption, i: number) => {
     return (
       <HStack key={i} spacing={4}>
-        <Checkbox sx={styles.checkbox} isChecked={false} />
+        <Checkbox
+          sx={styles.checkbox}
+          className="big-checkbox"
+          isChecked={false}
+        />
         <Input
           type="text"
           value={option.label}
@@ -174,6 +178,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
             <Flex key={i} sx={styles.previewOptionRowContainer}>
               <Checkbox
                 sx={styles.checkbox}
+                className="big-checkbox"
                 spacing={4}
                 value={value}
                 isChecked={false}

--- a/src/client/components/builder/questions/CheckboxField.tsx
+++ b/src/client/components/builder/questions/CheckboxField.tsx
@@ -23,6 +23,7 @@ import { useCheckerContext } from '../../../contexts'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 
 import '../../../styles/big-checkbox.css'
+import { FieldIndexText } from './FieldIndexText'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
@@ -156,7 +157,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   )
 }
 
-const PreviewComponent: QuestionFieldComponent = ({ field }) => {
+const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description, options } = field
   const commonStyles = useStyles()
   const styles = useMultiStyleConfig('CheckboxField', {})
@@ -165,7 +166,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
     <VStack sx={commonStyles.fullWidthContainer} spacing={2}>
       <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiSelectMultiple fontSize="20px" />
+          <FieldIndexText index={index} />
           <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
         {description && (

--- a/src/client/components/builder/questions/DateField.tsx
+++ b/src/client/components/builder/questions/DateField.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { BiCalendar } from 'react-icons/bi'
 import {
   useStyles,
-  Box,
   HStack,
   VStack,
   Text,
   Input,
   InputGroup,
   InputRightElement,
+  InputLeftElement,
 } from '@chakra-ui/react'
 
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
@@ -17,7 +17,8 @@ import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
-  const styles = useStyles()
+  const commonStyles = useStyles()
+
   const { dispatch } = useCheckerContext()
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -32,59 +33,65 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiCalendar />
-      </Box>
-      <VStack align="stretch" w="90%">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiCalendar />}
+        />
         <Input
           type="text"
+          sx={commonStyles.fieldInput}
           placeholder="Question"
           name="title"
           onChange={handleChange}
           value={title}
         />
+      </InputGroup>
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name="description"
+        placeholder="Description"
+        onChange={handleChange}
+        value={description}
+      />
+      <InputGroup sx={commonStyles.halfWidthContainer}>
         <Input
           type="text"
-          name="description"
-          placeholder="Description"
-          onChange={handleChange}
-          value={description}
+          placeholder="DD/MM/YYYY"
+          sx={commonStyles.dummyInput}
+          disabled
         />
-        <InputGroup w="50%">
-          <Input
-            type="text"
-            placeholder="DD/MM/YYYY"
-            sx={styles.dummyInput}
-            disabled
-          />
-          <InputRightElement
-            pointerEvents="none"
-            children={<BiCalendar opacity={0.7} />}
-          />
-        </InputGroup>
-      </VStack>
-    </HStack>
+        <InputRightElement
+          pointerEvents="none"
+          children={<BiCalendar opacity={0.7} />}
+        />
+      </InputGroup>
+    </VStack>
   )
 }
 
 const PreviewComponent: QuestionFieldComponent = ({ field }) => {
   const { title, description } = field
-  const styles = useStyles()
+  const commonStyles = useStyles()
+
   return (
-    <VStack align="stretch" w="100%" spacing={6}>
-      <VStack align="stretch">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
+      <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
           <BiCalendar fontSize="20px" />
-          <Text>{title}</Text>
+          <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
-        {description && <Text color="secondary.400">{description}</Text>}
+        {description && (
+          <Text sx={commonStyles.previewDescription}>{description}</Text>
+        )}
       </VStack>
-      <InputGroup w="50%">
+      <InputGroup sx={commonStyles.halfWidthContainer}>
         <Input
           type="text"
           placeholder="DD/MM/YYYY"
-          sx={styles.dummyInput}
+          sx={commonStyles.dummyInput}
           disabled
         />
         <InputRightElement

--- a/src/client/components/builder/questions/DateField.tsx
+++ b/src/client/components/builder/questions/DateField.tsx
@@ -14,6 +14,7 @@ import {
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { useCheckerContext } from '../../../contexts'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { FieldIndexText } from './FieldIndexText'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
@@ -72,7 +73,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   )
 }
 
-const PreviewComponent: QuestionFieldComponent = ({ field }) => {
+const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
   const commonStyles = useStyles()
 
@@ -80,7 +81,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
     <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
       <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiCalendar fontSize="20px" />
+          <FieldIndexText index={index} />
           <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
         {description && (

--- a/src/client/components/builder/questions/DropdownField.tsx
+++ b/src/client/components/builder/questions/DropdownField.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { BiListUl } from 'react-icons/bi'
 import {
-  Box,
   HStack,
   VStack,
   Text,
@@ -9,6 +8,8 @@ import {
   Select,
   Textarea,
   useStyles,
+  InputGroup,
+  InputLeftElement,
 } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
@@ -18,6 +19,7 @@ import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
   const { dispatch } = useCheckerContext()
+  const commonStyles = useStyles()
 
   const updateTitleOrDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -46,52 +48,57 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiListUl />
-      </Box>
-      <VStack align="stretch" w="90%" spacing={6}>
-        <VStack align="stretch" spacing={2}>
-          <Input
-            type="text"
-            name="title"
-            placeholder="Question"
-            onChange={updateTitleOrDescription}
-            value={title}
-          />
-          <Input
-            type="text"
-            name="description"
-            placeholder="Description"
-            onChange={updateTitleOrDescription}
-            value={description}
-          />
-        </VStack>
-        <VStack spacing={4} alignItems="left" w="50%">
-          <Textarea
-            value={field.options.map((o) => o.label).join('\n')}
-            onChange={changeOptions}
-            placeholder="Enter each option on a new line"
-          />
-        </VStack>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiListUl />}
+        />
+        <Input
+          type="text"
+          sx={commonStyles.fieldInput}
+          name="title"
+          placeholder="Question"
+          onChange={updateTitleOrDescription}
+          value={title}
+        />
+      </InputGroup>
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name="description"
+        placeholder="Description"
+        onChange={updateTitleOrDescription}
+        value={description}
+      />
+      <VStack sx={commonStyles.halfWidthContainer} spacing={4}>
+        <Textarea
+          sx={commonStyles.fieldInput}
+          value={field.options.map((o) => o.label).join('\n')}
+          onChange={changeOptions}
+          placeholder="Enter each option on a new line"
+        />
       </VStack>
-    </HStack>
+    </VStack>
   )
 }
 
 const PreviewComponent: QuestionFieldComponent = ({ field }) => {
   const { title, description, options } = field
-  const styles = useStyles()
+  const commonStyles = useStyles()
+
   return (
-    <VStack align="stretch" w="100%" spacing={6}>
-      <VStack align="stretch">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
+      <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
           <BiListUl fontSize="20px" />
-          <Text>{title}</Text>
+          <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
-        {description && <Text color="secondary.400">{description}</Text>}
+        {description && (
+          <Text sx={commonStyles.previewDescription}>{description}</Text>
+        )}
       </VStack>
-      <Select isDisabled sx={styles.dummyInput}>
+      <Select isDisabled sx={commonStyles.dummyInput}>
         {options.map(({ value, label }, i) => (
           <option key={i} value={value}>
             {label}

--- a/src/client/components/builder/questions/DropdownField.tsx
+++ b/src/client/components/builder/questions/DropdownField.tsx
@@ -15,6 +15,7 @@ import {
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { FieldIndexText } from './FieldIndexText'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
@@ -83,7 +84,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   )
 }
 
-const PreviewComponent: QuestionFieldComponent = ({ field }) => {
+const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description, options } = field
   const commonStyles = useStyles()
 
@@ -91,7 +92,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
     <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
       <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiListUl fontSize="20px" />
+          <FieldIndexText index={index} />
           <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
         {description && (

--- a/src/client/components/builder/questions/FieldIndexText.tsx
+++ b/src/client/components/builder/questions/FieldIndexText.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from 'react'
+import { Text, TextProps, useStyleConfig } from '@chakra-ui/react'
+
+interface FieldIndexTextProps extends TextProps {
+  index: number
+}
+
+export const FieldIndexText: FC<FieldIndexTextProps> = ({ index }) => {
+  const style = useStyleConfig('FieldIndexText', {})
+
+  return (
+    <Text sx={style}>{`${index + 1}.`}</Text> // user-facing index starts from 1
+  )
+}

--- a/src/client/components/builder/questions/NumericField.tsx
+++ b/src/client/components/builder/questions/NumericField.tsx
@@ -1,6 +1,15 @@
 import React from 'react'
 import { BiHash } from 'react-icons/bi'
-import { useStyles, Box, HStack, VStack, Text, Input } from '@chakra-ui/react'
+import {
+  useStyles,
+  HStack,
+  VStack,
+  Text,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
 
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { useCheckerContext } from '../../../contexts'
@@ -8,7 +17,9 @@ import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
-  const styles = useStyles()
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('NumericField', {})
+
   const { dispatch } = useCheckerContext()
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -23,54 +34,59 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiHash />
-      </Box>
-      <VStack align="stretch" w="90%">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiHash />}
+        />
         <Input
           type="text"
+          sx={commonStyles.fieldInput}
           placeholder="Question"
           name="title"
           onChange={handleChange}
           value={title}
         />
-        <Input
-          type="text"
-          name="description"
-          placeholder="Description"
-          onChange={handleChange}
-          value={description}
-        />
-        <Input
-          type="text"
-          placeholder="Enter number"
-          w="50%"
-          sx={styles.dummyInput}
-          disabled
-        />
-      </VStack>
-    </HStack>
+      </InputGroup>
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name="description"
+        placeholder="Description"
+        onChange={handleChange}
+        value={description}
+      />
+      <Input
+        type="text"
+        placeholder="Enter number"
+        sx={{ ...commonStyles.dummyInput, ...styles.numericInput }}
+        disabled
+      />
+    </VStack>
   )
 }
 
 const PreviewComponent: QuestionFieldComponent = ({ field }) => {
   const { title, description } = field
-  const styles = useStyles()
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('NumericField', {})
+
   return (
-    <VStack align="stretch" w="100%" spacing={6}>
-      <VStack align="stretch">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
+      <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
           <BiHash fontSize="20px" />
-          <Text>{title}</Text>
+          <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
-        {description && <Text color="secondary.400">{description}</Text>}
+        {description && (
+          <Text sx={commonStyles.previewDescription}>{description}</Text>
+        )}
       </VStack>
       <Input
-        w="50%"
         type="text"
         placeholder="Enter number"
-        sx={styles.dummyInput}
+        sx={{ ...commonStyles.dummyInput, ...styles.numericInput }}
         disabled
       />
     </VStack>

--- a/src/client/components/builder/questions/NumericField.tsx
+++ b/src/client/components/builder/questions/NumericField.tsx
@@ -14,6 +14,7 @@ import {
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { useCheckerContext } from '../../../contexts'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { FieldIndexText } from './FieldIndexText'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
@@ -67,7 +68,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   )
 }
 
-const PreviewComponent: QuestionFieldComponent = ({ field }) => {
+const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
   const commonStyles = useStyles()
   const styles = useMultiStyleConfig('NumericField', {})
@@ -76,7 +77,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
     <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
       <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiHash fontSize="20px" />
+          <FieldIndexText index={index} />
           <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
         {description && (

--- a/src/client/components/builder/questions/RadioField.tsx
+++ b/src/client/components/builder/questions/RadioField.tsx
@@ -1,15 +1,20 @@
 import React from 'react'
-import { BiListUl, BiX } from 'react-icons/bi'
+import { BiPlus, BiRadioCircleMarked, BiTrash } from 'react-icons/bi'
 import {
   Button,
   IconButton,
-  Box,
   HStack,
   VStack,
   Text,
   Input,
   Radio,
   RadioGroup,
+  InputGroup,
+  InputLeftElement,
+  useMultiStyleConfig,
+  useStyles,
+  Icon,
+  Flex,
 } from '@chakra-ui/react'
 
 import * as checker from '../../../../types/checker'
@@ -20,6 +25,8 @@ import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
   const { dispatch } = useCheckerContext()
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('RadioField', {})
 
   const updateTitleOrDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -80,8 +87,8 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
 
   const renderOption = (option: checker.FieldOption, i: number) => {
     return (
-      <HStack key={i}>
-        <Radio isChecked={false} />
+      <HStack key={i} spacing={4}>
+        <Radio sx={styles.radio} isChecked={false} />
         <Input
           type="text"
           value={option.label}
@@ -90,9 +97,11 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
           }}
         />
         <IconButton
+          sx={styles.deleteOptionButton}
+          colorScheme="error"
           aria-label="Delete option"
-          fontSize="20px"
-          icon={<BiX />}
+          icon={<BiTrash />}
+          variant="link"
           disabled={field.options.length <= 1}
           onClick={() => deleteOption(option, i)}
         />
@@ -101,60 +110,75 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiListUl />
-      </Box>
-      <VStack align="stretch" w="90%" spacing={6}>
-        <VStack align="stretch" spacing={2}>
-          <Input
-            type="text"
-            name="title"
-            placeholder="Question"
-            onChange={updateTitleOrDescription}
-            value={title}
-          />
-          <Input
-            type="text"
-            name="description"
-            placeholder="Description"
-            onChange={updateTitleOrDescription}
-            value={description}
-          />
-        </VStack>
-        <VStack spacing={4} alignItems="left" w="50%">
-          {field.options.map(renderOption)}
-          <HStack h={10}>
-            <Radio isChecked={false} />
-            <Box pl={2}>
-              <Button variant="link" onClick={addOption}>
-                Add new option
-              </Button>
-            </Box>
-          </HStack>
-        </VStack>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiRadioCircleMarked />}
+        />
+        <Input
+          type="text"
+          sx={commonStyles.fieldInput}
+          name="title"
+          placeholder="Question"
+          onChange={updateTitleOrDescription}
+          value={title}
+        />
+      </InputGroup>
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name="description"
+        placeholder="Description"
+        onChange={updateTitleOrDescription}
+        value={description}
+      />
+      <VStack sx={commonStyles.halfWidthContainer} spacing={4}>
+        {field.options.map(renderOption)}
+        <HStack sx={styles.addOptionContainer} spacing={4}>
+          <Icon as={BiPlus} sx={styles.addOptionIcon} />
+          <Button
+            variant="link"
+            sx={styles.addOptionButton}
+            onClick={addOption}
+          >
+            Add option
+          </Button>
+        </HStack>
       </VStack>
-    </HStack>
+    </VStack>
   )
 }
 
 const PreviewComponent: QuestionFieldComponent = ({ field }) => {
   const { title, description, options } = field
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('RadioField', {})
+
   return (
-    <VStack align="stretch" w="100%" spacing={6}>
-      <VStack align="stretch">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={2}>
+      <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiListUl fontSize="20px" />
-          <Text>{title}</Text>
+          <BiRadioCircleMarked fontSize="20px" />
+          <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
-        {description && <Text color="secondary.400">{description}</Text>}
+        {description && (
+          <Text sx={commonStyles.previewDescription}>{description}</Text>
+        )}
       </VStack>
       <RadioGroup>
-        <VStack alignItems="left" spacing={2}>
+        <VStack sx={styles.previewOptionsContainer} spacing={0}>
           {options.map(({ value, label }, i) => (
-            <Radio key={i} value={value} isChecked={false}>
-              {label}
-            </Radio>
+            <Flex key={i} sx={styles.previewOptionRowContainer}>
+              <Radio
+                sx={styles.radio}
+                spacing={4}
+                value={value}
+                isChecked={false}
+              >
+                <Text sx={styles.radioText}>{label}</Text>
+              </Radio>
+            </Flex>
           ))}
         </VStack>
       </RadioGroup>

--- a/src/client/components/builder/questions/RadioField.tsx
+++ b/src/client/components/builder/questions/RadioField.tsx
@@ -21,6 +21,7 @@ import * as checker from '../../../../types/checker'
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
+import { FieldIndexText } from './FieldIndexText'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
@@ -150,7 +151,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   )
 }
 
-const PreviewComponent: QuestionFieldComponent = ({ field }) => {
+const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description, options } = field
   const commonStyles = useStyles()
   const styles = useMultiStyleConfig('RadioField', {})
@@ -159,7 +160,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field }) => {
     <VStack sx={commonStyles.fullWidthContainer} spacing={2}>
       <VStack sx={commonStyles.fullWidthContainer} spacing={0}>
         <HStack>
-          <BiRadioCircleMarked fontSize="20px" />
+          <FieldIndexText index={index} />
           <Text sx={commonStyles.previewTitle}>{title}</Text>
         </HStack>
         {description && (

--- a/src/client/components/builder/questions/TitleField.tsx
+++ b/src/client/components/builder/questions/TitleField.tsx
@@ -5,6 +5,7 @@ import {
   Input,
   useStyles,
   useMultiStyleConfig,
+  Textarea,
 } from '@chakra-ui/react'
 
 import { createBuilderField, TitleFieldComponent } from '../BuilderField'
@@ -19,8 +20,13 @@ const enum SettingsName {
 const InputComponent: TitleFieldComponent = ({ title, description }) => {
   const { dispatch } = useCheckerContext()
   const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('TitleField', {})
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    e:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
     const { name, value } = e.target
     const update = { settingsName: name as SettingsName, value }
 
@@ -40,9 +46,9 @@ const InputComponent: TitleFieldComponent = ({ title, description }) => {
         onChange={handleChange}
         value={title}
       />
-      <Input
+      <Textarea
         type="text"
-        sx={commonStyles.fieldInput}
+        sx={styles.descriptionTextarea}
         name={SettingsName.description}
         placeholder="Description"
         onChange={handleChange}

--- a/src/client/components/builder/questions/TitleField.tsx
+++ b/src/client/components/builder/questions/TitleField.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
-import { BiText } from 'react-icons/bi'
-import { Box, HStack, VStack, Text, Input, Heading } from '@chakra-ui/react'
+import {
+  VStack,
+  Text,
+  Input,
+  useStyles,
+  useMultiStyleConfig,
+} from '@chakra-ui/react'
 
 import { createBuilderField, TitleFieldComponent } from '../BuilderField'
 import { useCheckerContext } from '../../../contexts'
@@ -13,6 +18,7 @@ const enum SettingsName {
 
 const InputComponent: TitleFieldComponent = ({ title, description }) => {
   const { dispatch } = useCheckerContext()
+  const commonStyles = useStyles()
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -25,35 +31,35 @@ const InputComponent: TitleFieldComponent = ({ title, description }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiText />
-      </Box>
-      <VStack align="stretch" w="100%">
-        <Input
-          type="text"
-          name={SettingsName.title}
-          placeholder="Title"
-          onChange={handleChange}
-          value={title}
-        />
-        <Input
-          type="text"
-          name={SettingsName.description}
-          placeholder="Description"
-          onChange={handleChange}
-          value={description}
-        />
-      </VStack>
-    </HStack>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name={SettingsName.title}
+        placeholder="Title"
+        onChange={handleChange}
+        value={title}
+      />
+      <Input
+        type="text"
+        sx={commonStyles.fieldInput}
+        name={SettingsName.description}
+        placeholder="Description"
+        onChange={handleChange}
+        value={description}
+      />
+    </VStack>
   )
 }
 
 const PreviewComponent: TitleFieldComponent = ({ title, description }) => {
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('TitleField', {})
+
   return (
-    <VStack align="stretch" w="100%">
-      <Heading size="lg">{title}</Heading>
-      <Text>{description}</Text>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <Text sx={styles.titlePreview}>{title}</Text>
+      <Text sx={styles.descriptionPreview}>{description}</Text>
     </VStack>
   )
 }

--- a/src/client/styles/big-checkbox.css
+++ b/src/client/styles/big-checkbox.css
@@ -1,0 +1,24 @@
+/*
+  Applies custom width and height styles for Chakra UI checkboxes.
+
+  This is necessary, as width and height theme props are not applied onto the control
+  element, but rather the encapsulating label element. Additionally, the `size` prop only
+  accepts 'sm'/'md'/'lg' strings, and cannot parse pixel values.
+
+  As such, the current workaround for now is to directly apply the width and height styles
+  directly through class selector styling methods, which will bypass the Chakra theming system.
+
+  ---
+
+  Usage:
+  
+  <Checkbox className="big-checkbox">...</Checkbox>
+
+  ---
+
+  Refer to https://chakra-ui.com/docs/form/checkbox for more information.
+*/
+.big-checkbox .chakra-checkbox__control {
+  width: 24px;
+  height: 24px;
+}

--- a/src/client/theme/components/Checker.ts
+++ b/src/client/theme/components/Checker.ts
@@ -11,6 +11,7 @@ export const Checker = {
       size: '16px',
       lineHeight: '24px',
       color: 'secondary.400',
+      whiteSpace: 'pre-wrap',
     },
     label: {
       textStyle: 'subhead1',

--- a/src/client/theme/components/Checker.ts
+++ b/src/client/theme/components/Checker.ts
@@ -5,7 +5,7 @@ export const Checker = {
       fontSize: '26px',
       lineHeight: '32px',
       fontWeight: 600,
-      textAlign: 'center',
+      maxW: '100%',
     },
     subtitle: {
       size: '16px',

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -1,7 +1,7 @@
 import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
 
 const CommonComponents: ComponentMultiStyleConfig = {
-  parts: ['dummyInput'],
+  parts: ['dummyInput', 'fieldInput', 'fullWidthContainer'],
   baseStyle: {
     dummyInput: {
       bg: 'neutral.200',
@@ -9,6 +9,13 @@ const CommonComponents: ComponentMultiStyleConfig = {
         opacity: 1.0,
         cursor: 'not-allowed',
       },
+    },
+    fieldInput: {
+      textStyle: 'body1',
+    },
+    fullWidthContainer: {
+      alignItems: 'stretch',
+      width: '100%',
     },
   },
 }

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -6,6 +6,7 @@ const CommonComponents: ComponentMultiStyleConfig = {
     'fieldInput',
     'inputIconElement',
     'fullWidthContainer',
+    'halfWidthContainer',
     'previewTitle',
     'previewDescription',
   ],
@@ -28,6 +29,10 @@ const CommonComponents: ComponentMultiStyleConfig = {
     fullWidthContainer: {
       alignItems: 'stretch',
       width: '100%',
+    },
+    halfWidthContainer: {
+      alignItems: 'stretch',
+      width: '50%',
     },
     previewTitle: {
       textStyle: 'subhead1',

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -1,7 +1,14 @@
 import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
 
 const CommonComponents: ComponentMultiStyleConfig = {
-  parts: ['dummyInput', 'fieldInput', 'fullWidthContainer'],
+  parts: [
+    'dummyInput',
+    'fieldInput',
+    'inputIconElement',
+    'fullWidthContainer',
+    'previewTitle',
+    'previewDescription',
+  ],
   baseStyle: {
     dummyInput: {
       bg: 'neutral.200',
@@ -13,9 +20,22 @@ const CommonComponents: ComponentMultiStyleConfig = {
     fieldInput: {
       textStyle: 'body1',
     },
+    inputIconElement: {
+      pointerEvents: 'none',
+      fontSize: '16px',
+      pl: 1,
+    },
     fullWidthContainer: {
       alignItems: 'stretch',
       width: '100%',
+    },
+    previewTitle: {
+      textStyle: 'subhead1',
+      fontWeight: 500,
+    },
+    previewDescription: {
+      textStyle: 'body2',
+      color: 'secondary.400',
     },
   },
 }

--- a/src/client/theme/components/builder/index.ts
+++ b/src/client/theme/components/builder/index.ts
@@ -1,7 +1,9 @@
 import { BuilderField } from './BuilderField'
 import { ActionButton } from './ActionButton'
+import { questions } from './questions'
 
 export const builder = {
   BuilderField,
   ActionButton,
+  ...questions,
 }

--- a/src/client/theme/components/builder/questions/CheckboxField.tsx
+++ b/src/client/theme/components/builder/questions/CheckboxField.tsx
@@ -1,0 +1,47 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const CheckboxField: ComponentMultiStyleConfig = {
+  parts: [
+    'deleteOptionButton',
+    'addOptionContainer',
+    'addOptionIcon',
+    'addOptionButton',
+    'previewOptionsContainer',
+    'previewOptionRowContainer',
+    'checkbox',
+    'checkboxText',
+  ],
+  baseStyle: {
+    deleteOptionButton: {
+      minW: 6,
+      h: 6,
+      fontSize: '24px',
+    },
+    addOptionContainer: {
+      h: '40px',
+    },
+    addOptionIcon: {
+      fontSize: '24px',
+      color: 'neutral.800',
+    },
+    addOptionButton: {
+      color: 'neutral.800',
+      textStyle: 'body1',
+      fontWeight: '400',
+    },
+    previewOptionsContainer: {
+      alignItems: 'start',
+    },
+    previewOptionRowContainer: {
+      h: '40px',
+      px: 2,
+      alignItems: 'center',
+    },
+    checkbox: {
+      borderColor: 'secondary.500',
+    },
+    checkboxText: {
+      textStyle: 'body1',
+    },
+  },
+}

--- a/src/client/theme/components/builder/questions/FieldIndexText.tsx
+++ b/src/client/theme/components/builder/questions/FieldIndexText.tsx
@@ -1,0 +1,7 @@
+import { ComponentSingleStyleConfig } from '@chakra-ui/theme'
+
+export const FieldIndexText: ComponentSingleStyleConfig = {
+  baseStyle: {
+    textStyle: 'caption1',
+  },
+}

--- a/src/client/theme/components/builder/questions/NumericField.tsx
+++ b/src/client/theme/components/builder/questions/NumericField.tsx
@@ -1,0 +1,10 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const NumericField: ComponentMultiStyleConfig = {
+  parts: ['numericInput'],
+  baseStyle: {
+    numericInput: {
+      w: '50%',
+    },
+  },
+}

--- a/src/client/theme/components/builder/questions/RadioField.tsx
+++ b/src/client/theme/components/builder/questions/RadioField.tsx
@@ -1,0 +1,49 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const RadioField: ComponentMultiStyleConfig = {
+  parts: [
+    'deleteOptionButton',
+    'addOptionContainer',
+    'addOptionIcon',
+    'addOptionButton',
+    'previewOptionsContainer',
+    'previewOptionRowContainer',
+    'radio',
+    'radioText',
+  ],
+  baseStyle: {
+    deleteOptionButton: {
+      minW: 6,
+      h: 6,
+      fontSize: '24px',
+    },
+    addOptionContainer: {
+      h: '40px',
+    },
+    addOptionIcon: {
+      fontSize: '24px',
+      color: 'neutral.800',
+    },
+    addOptionButton: {
+      color: 'neutral.800',
+      textStyle: 'body1',
+      fontWeight: '400',
+    },
+    previewOptionsContainer: {
+      alignItems: 'start',
+    },
+    previewOptionRowContainer: {
+      h: '40px',
+      px: 2,
+      alignItems: 'center',
+    },
+    radio: {
+      h: 6,
+      w: 6,
+      borderColor: 'secondary.500',
+    },
+    radioText: {
+      textStyle: 'body1',
+    },
+  },
+}

--- a/src/client/theme/components/builder/questions/TitleField.tsx
+++ b/src/client/theme/components/builder/questions/TitleField.tsx
@@ -1,0 +1,14 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const TitleField: ComponentMultiStyleConfig = {
+  parts: ['titlePreview', 'descriptionPreview'],
+  baseStyle: {
+    titlePreview: {
+      textStyle: 'heading2',
+    },
+    descriptionPreview: {
+      textStyle: 'body2',
+      color: 'secondary.400',
+    },
+  },
+}

--- a/src/client/theme/components/builder/questions/TitleField.tsx
+++ b/src/client/theme/components/builder/questions/TitleField.tsx
@@ -9,6 +9,11 @@ export const TitleField: ComponentMultiStyleConfig = {
     descriptionPreview: {
       textStyle: 'body2',
       color: 'secondary.400',
+      whiteSpace: 'pre-wrap',
+    },
+    descriptionTextarea: {
+      resize: 'vertical',
+      textStyle: 'body1',
     },
   },
 }

--- a/src/client/theme/components/builder/questions/index.ts
+++ b/src/client/theme/components/builder/questions/index.ts
@@ -1,7 +1,9 @@
 import { TitleField } from './TitleField'
 import { NumericField } from './NumericField'
+import { RadioField } from './RadioField'
 
 export const questions = {
   TitleField,
   NumericField,
+  RadioField,
 }

--- a/src/client/theme/components/builder/questions/index.ts
+++ b/src/client/theme/components/builder/questions/index.ts
@@ -1,9 +1,11 @@
 import { TitleField } from './TitleField'
 import { NumericField } from './NumericField'
 import { RadioField } from './RadioField'
+import { CheckboxField } from './CheckboxField'
 
 export const questions = {
   TitleField,
   NumericField,
   RadioField,
+  CheckboxField,
 }

--- a/src/client/theme/components/builder/questions/index.ts
+++ b/src/client/theme/components/builder/questions/index.ts
@@ -1,0 +1,5 @@
+import { TitleField } from './TitleField'
+
+export const questions = {
+  TitleField,
+}

--- a/src/client/theme/components/builder/questions/index.ts
+++ b/src/client/theme/components/builder/questions/index.ts
@@ -2,10 +2,12 @@ import { TitleField } from './TitleField'
 import { NumericField } from './NumericField'
 import { RadioField } from './RadioField'
 import { CheckboxField } from './CheckboxField'
+import { FieldIndexText } from './FieldIndexText'
 
 export const questions = {
   TitleField,
   NumericField,
   RadioField,
   CheckboxField,
+  FieldIndexText,
 }

--- a/src/client/theme/components/builder/questions/index.ts
+++ b/src/client/theme/components/builder/questions/index.ts
@@ -1,5 +1,7 @@
 import { TitleField } from './TitleField'
+import { NumericField } from './NumericField'
 
 export const questions = {
   TitleField,
+  NumericField,
 }


### PR DESCRIPTION
## Problem

Updates the `TitleField`, `NumericField`, `RadioField`, `DropdownField`, `CheckboxField` and `DateField` components to align with the new design system.

Part of #549

## Solution

**Features**:

- Implement textarea for description inputs, including supporting newline characters
- Implement index number badges for question fields
- Implement big radio / checkboxes for radio and checkbox fields

**Improvements**:

- Organize question field styles into its own individual folder
- Align question field layout and styles with design system

## Before & After Screenshots

**BEFORE**:
<img width="1792" alt="Screenshot 2021-06-04 at 4 54 55 PM" src="https://user-images.githubusercontent.com/21305518/120775372-b84edc00-c555-11eb-9c55-f78b7d35a670.png">

**AFTER**:
<img width="1792" alt="Screenshot 2021-06-04 at 4 54 28 PM" src="https://user-images.githubusercontent.com/21305518/120775424-c1d84400-c555-11eb-9ef7-e4dfb40c1365.png">

## Tests

- [ ] Implement textarea for description inputs, including supporting newline characters
  - [ ] Check that the design lines up with the design system
  - [ ] Check that input works and changes are dispatched correctly
  - [ ] Check that newlines work in the field preview and checker preview
  - [ ] Check that the description is center aligned on the checker preview when it can fit on one line
  - [ ] Check that the description is left aligned on the checker preview when it takes up more than one line (or has a newline)
- [ ] Implement index number badges for question fields
  - [ ] Check that the index numbers are correct on a form (1-indexed)
  - [ ] Check that shifting fields up and down update the index numbers correctly
- [ ] Implement big radio / checkboxes for radio and checkbox fields
  - [ ] Check that the design lines up with the design system
  - [ ] Check that the radio / checkboxes checked states match the increased sizes correctly
- [ ] Verify that the new layout aligns with the design system (scope: question tab)
