### PR TITLE
feat(constant-fields): align constant tab fields with design system

### DIFF
--- a/src/client/components/builder/constants/MapTable.tsx
+++ b/src/client/components/builder/constants/MapTable.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import { BiTable, BiTrash, BiPlusCircle } from 'react-icons/bi'
+import { BiTable, BiTrash, BiPlus } from 'react-icons/bi'
 import {
   IconButton,
   Button,
-  Box,
   HStack,
   VStack,
   Text,
@@ -14,6 +13,10 @@ import {
   Tr,
   Th,
   Td,
+  InputGroup,
+  InputLeftElement,
+  useMultiStyleConfig,
+  useStyles,
 } from '@chakra-ui/react'
 
 import * as checker from '../../../../types/checker'
@@ -25,6 +28,8 @@ import { DefaultTooltip } from '../../common/DefaultTooltip'
 const InputComponent: ConstantFieldComponent = ({ constant, index }) => {
   const { title, table } = constant
   const { dispatch } = useCheckerContext()
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('MapTable', {})
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -79,112 +84,132 @@ const InputComponent: ConstantFieldComponent = ({ constant, index }) => {
   }
 
   return (
-    <>
-      <HStack w="100%" alignItems="flex-start">
-        <Box fontSize="20px" pt={2}>
-          <BiTable />
-        </Box>
-        <VStack align="stretch" w="100%">
-          <Input
-            type="text"
-            placeholder="Table Name"
-            name="title"
-            onChange={handleTitleChange}
-            value={title}
-          />
-          <Table variant="simple">
-            <Thead>
-              <Tr>
-                <Th>Reference</Th>
-                <Th>Constant</Th>
-                <Th />
-              </Tr>
-            </Thead>
-          </Table>
+    <VStack
+      sx={{ ...commonStyles.fullWidthContainer, ...styles.fieldContainer }}
+      spacing={4}
+    >
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiTable />}
+        />
+        <Input
+          type="text"
+          sx={commonStyles.fieldInput}
+          placeholder="Table Name"
+          name="title"
+          onChange={handleTitleChange}
+          value={title}
+        />
+      </InputGroup>
+      <Table sx={styles.table} variant="simple" colorScheme="table">
+        <Thead>
+          <Tr>
+            <Th sx={styles.tableHead}>
+              <Text sx={styles.tableHeadText}>Reference</Text>
+            </Th>
+            <Th sx={styles.tableHead}>
+              <Text sx={styles.tableHeadText}>Constant</Text>
+            </Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>
           {table.map(({ key, value }, index) => (
-            <HStack w="100%" alignItems="flex-start" key={index}>
-              <Input
-                type="text"
-                placeholder="Reference"
-                name="Reference"
-                onChange={(e) => {
-                  handleUpdateTableRow({ key: e.target.value, value }, index)
-                }}
-                value={key}
-                w="45%"
-              />
-              <Input
-                type="number"
-                placeholder="Constant"
-                name="constant"
-                onChange={(e) => {
-                  handleUpdateTableRow(
-                    { key, value: Number(e.target.value) },
-                    index
-                  )
-                }}
-                value={value}
-                w="45%"
-              />
-              <DefaultTooltip label="Delete mapping" placement="right">
-                <IconButton
-                  borderRadius={0}
-                  variant="ghost"
-                  aria-label="delete item"
-                  fontSize="20px"
-                  icon={<BiTrash />}
-                  onClick={() => handleDeleteTableRow(index)}
+            <Tr key={index}>
+              <Td sx={styles.tableCell}>
+                <Input
+                  sx={styles.tableInput}
+                  type="text"
+                  placeholder="Reference"
+                  name="Reference"
+                  onChange={(e) => {
+                    handleUpdateTableRow({ key: e.target.value, value }, index)
+                  }}
+                  value={key}
                 />
-              </DefaultTooltip>
-            </HStack>
+              </Td>
+              <Td sx={styles.tableCell}>
+                <Input
+                  sx={styles.tableInput}
+                  type="number"
+                  placeholder="Numeric Value"
+                  name="constant"
+                  onChange={(e) => {
+                    handleUpdateTableRow(
+                      { key, value: Number(e.target.value) },
+                      index
+                    )
+                  }}
+                  value={value}
+                />
+              </Td>
+              <Td sx={styles.deleteCell}>
+                <DefaultTooltip label="Delete mapping" placement="right">
+                  <IconButton
+                    sx={styles.deleteButton}
+                    variant="link"
+                    colorScheme="error"
+                    aria-label="delete item"
+                    icon={<BiTrash />}
+                    onClick={() => handleDeleteTableRow(index)}
+                  />
+                </DefaultTooltip>
+              </Td>
+            </Tr>
           ))}
-          <Button
-            leftIcon={<BiPlusCircle />}
-            variant="outline"
-            colorScheme="primary"
-            aria-label="add map item"
-            onClick={handleAddTableRow}
-            w="91.25%"
-          >
-            Add map constant
-          </Button>
-        </VStack>
-      </HStack>
-    </>
+        </Tbody>
+      </Table>
+      <Button
+        leftIcon={<BiPlus />}
+        sx={styles.addRowButton}
+        variant="solid"
+        colorScheme="primary"
+        aria-label="add map item"
+        onClick={handleAddTableRow}
+      >
+        Add row
+      </Button>
+    </VStack>
   )
 }
 
 const PreviewComponent: ConstantFieldComponent = ({ constant }) => {
   const { title, table } = constant
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('MapTable', {})
+
   return (
-    <VStack align="stretch" w="100%" spacing={6}>
-      <VStack align="stretch">
-        <HStack>
-          <BiTable fontSize="20px" />
-          <Text>{title}</Text>
-        </HStack>
-        <HStack>
-          <Table variant="simple">
-            <Thead>
-              <Tr>
-                <Th>Reference</Th>
-                <Th>Constant</Th>
-                <Th />
+    <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
+      <HStack>
+        <BiTable fontSize="20px" />
+        <Text sx={commonStyles.previewTitle}>{title}</Text>
+      </HStack>
+      <HStack>
+        <Table sx={styles.table} variant="simple" colorScheme="table">
+          <Thead>
+            <Tr>
+              <Th sx={styles.tableHead}>
+                <Text sx={styles.tableHeadText}>Reference</Text>
+              </Th>
+              <Th sx={styles.tableHead}>
+                <Text sx={styles.tableHeadText}>Constant</Text>
+              </Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody sx={styles.previewTableBody}>
+            {table.map(({ key, value }, index) => (
+              <Tr key={index}>
+                <Td>{key}</Td>
+                {/* Hide NaN value */}
+                {isNaN(value) ? <Td /> : <Td>{value}</Td>}
+                <Td />
               </Tr>
-            </Thead>
-            <Tbody>
-              {table.map(({ key, value }, index) => (
-                <Tr key={index}>
-                  <Td>{key}</Td>
-                  {/* Hide NaN value */}
-                  {isNaN(value) ? <Td /> : <Td>{value}</Td>}
-                  <Td />
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </HStack>
-      </VStack>
+            ))}
+          </Tbody>
+        </Table>
+      </HStack>
     </VStack>
   )
 }

--- a/src/client/components/builder/constants/MapTable.tsx
+++ b/src/client/components/builder/constants/MapTable.tsx
@@ -182,7 +182,7 @@ const PreviewComponent: ConstantFieldComponent = ({ constant }) => {
   return (
     <VStack sx={commonStyles.fullWidthContainer} spacing={3}>
       <HStack>
-        <BiTable fontSize="20px" />
+        <BiTable fontSize="16px" />
         <Text sx={commonStyles.previewTitle}>{title}</Text>
       </HStack>
       <HStack>

--- a/src/client/theme/components/builder/constants/MapTable.tsx
+++ b/src/client/theme/components/builder/constants/MapTable.tsx
@@ -1,0 +1,56 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const MapTable: ComponentMultiStyleConfig = {
+  parts: [
+    'fieldContainer',
+    'table',
+    'tableHead',
+    'tableHeadText',
+    'tableCell',
+    'tableInput',
+    'deleteCell',
+    'deleteButton',
+    'addRowButton',
+    'previewTableBody',
+  ],
+  baseStyle: {
+    fieldContainer: {
+      mb: -2,
+    },
+    table: {
+      background: 'neutral.200',
+    },
+    tableHead: {
+      py: 4,
+    },
+    tableHeadText: {
+      textTransform: 'none',
+      textColor: 'secondary.500',
+      textStyle: 'tablehead',
+    },
+    tableCell: {
+      px: 2,
+      pt: 2,
+      pb: 1,
+    },
+    tableInput: {
+      background: 'white',
+      w: '100%',
+    },
+    deleteCell: {
+      px: 0,
+      pt: 2,
+      pb: 1,
+      w: '48px',
+    },
+    deleteButton: {
+      fontSize: '20px',
+    },
+    addRowButton: {
+      w: 'fit-content',
+    },
+    previewTableBody: {
+      background: 'white',
+    },
+  },
+}

--- a/src/client/theme/components/builder/constants/index.ts
+++ b/src/client/theme/components/builder/constants/index.ts
@@ -1,0 +1,5 @@
+import { MapTable } from './MapTable'
+
+export const constants = {
+  MapTable,
+}

--- a/src/client/theme/components/builder/index.ts
+++ b/src/client/theme/components/builder/index.ts
@@ -1,9 +1,11 @@
 import { BuilderField } from './BuilderField'
 import { ActionButton } from './ActionButton'
 import { questions } from './questions'
+import { constants } from './constants'
 
 export const builder = {
   BuilderField,
   ActionButton,
   ...questions,
+  ...constants,
 }

--- a/src/client/theme/foundations/colors.ts
+++ b/src/client/theme/foundations/colors.ts
@@ -127,4 +127,7 @@ export const colors = {
     600: '#EEEEEE',
     700: '#DADEE3',
   },
+  table: {
+    100: '#DADEE3',
+  },
 }

--- a/src/client/theme/text-styles.ts
+++ b/src/client/theme/text-styles.ts
@@ -85,4 +85,11 @@ export const textStyles = {
     letterSpacing: '-0.022em',
     fontFeatureSettings: "'cv05' on",
   },
+  tablehead: {
+    fontSize: '0.75rem',
+    lineHeight: '1rem',
+    fontWeight: 500,
+    letterSpacing: '0em',
+    fontFeatureSettings: "'tnum' on, 'lnum' on, 'cv05' on",
+  },
 }


### PR DESCRIPTION
## Problem

Updates the `MapTable` component to align with the new design system.

Part of #549

## Solution

**Improvements**:

- updated text styles
- added necessary text styles for table headers
- added necessary color styles for table borders
- updated and simplified layout
- added new folder for constant tab field styles
- added additional field-specific styles in a separate theme file

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-06-07 at 11 55 41 AM](https://user-images.githubusercontent.com/21305518/120956946-4fe74100-c787-11eb-8c7b-b2ab5770dddb.png)

**AFTER**:
![Screenshot 2021-06-07 at 11 54 16 AM](https://user-images.githubusercontent.com/21305518/120956957-55dd2200-c787-11eb-9521-84e77510c2c3.png)

## Tests

- [ ] Verify that the new layout aligns with the design system (scope: constants tab fields)
