### PR TITLE
feat(logic-fields): align styles to design system

### DIFF
--- a/src/client/components/builder/BuilderField.tsx
+++ b/src/client/components/builder/BuilderField.tsx
@@ -7,6 +7,8 @@ import {
   Flex,
   HStack,
   Button,
+  Text,
+  Spacer,
 } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../contexts'
@@ -259,6 +261,14 @@ export const createBuilderField =
               sx={isTitleData(data) ? styles.barSpacer : styles.actionBar}
               spacing={0}
             >
+              {isOperationData(data) && (
+                <Text sx={styles.logicCaption}>
+                  {data.show
+                    ? 'The outcome of this block will be shown in your results'
+                    : 'The outcome of this block will not be shown as a result'}
+                </Text>
+              )}
+              <Spacer />
               {isOperationData(data) && (
                 <ActionButton
                   aria-label="Duplicate"

--- a/src/client/components/builder/logic/CalculatedResult.tsx
+++ b/src/client/components/builder/logic/CalculatedResult.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import { BiCalculator } from 'react-icons/bi'
-import { VStack, HStack, Box, Input } from '@chakra-ui/react'
+import {
+  VStack,
+  HStack,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  useStyles,
+} from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
 import { createBuilderField, OperationFieldComponent } from '../BuilderField'
@@ -11,6 +18,7 @@ import { FormulaPreview } from './FormulaPreview'
 const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   const { title, expression } = operation
   const { dispatch } = useCheckerContext()
+  const commonStyles = useStyles()
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -36,32 +44,34 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   }
 
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiCalculator />
-      </Box>
-      <VStack align="stretch" w="100%">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiCalculator />}
+        />
         <Input
           name="title"
+          sx={commonStyles.fieldInput}
           type="text"
           placeholder="Operation title"
           onChange={handleChange}
           value={title}
         />
-        <HStack>
-          <ExpressionInput
-            name="expression"
-            type="text"
-            placeholder="Enter expression"
-            fontFamily="mono"
-            value={expression}
-            onChange={(expression) =>
-              handleExpressionChange('expression', expression)
-            }
-          />
-        </HStack>
-      </VStack>
-    </HStack>
+      </InputGroup>
+      <HStack>
+        <ExpressionInput
+          name="expression"
+          sx={commonStyles.expressionInput}
+          type="text"
+          placeholder="Enter formula"
+          value={expression}
+          onChange={(expression) =>
+            handleExpressionChange('expression', expression)
+          }
+        />
+      </HStack>
+    </VStack>
   )
 }
 

--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -7,17 +7,11 @@ import {
 import { parseConditionalExpr } from '../../../core/parser'
 import { isValidExpression } from '../../../core/evaluator'
 import update, { Spec } from 'immutability-helper'
-import {
-  BiGitBranch,
-  BiPlusCircle,
-  BiTrash,
-  BiChevronDown,
-} from 'react-icons/bi'
+import { BiGitBranch, BiTrash, BiChevronDown, BiPlus } from 'react-icons/bi'
 import {
   Divider,
   Button,
   IconButton,
-  Heading,
   VStack,
   HStack,
   Box,
@@ -26,6 +20,11 @@ import {
   MenuButton,
   MenuList,
   MenuItem,
+  InputGroup,
+  InputLeftElement,
+  Text,
+  useMultiStyleConfig,
+  useStyles,
 } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
@@ -52,6 +51,9 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   const [ifelseState, setIfelseState] = useState<IfelseState>(
     parseConditionalExpr(expression)
   )
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('ConditionalResult', {})
+
   // Retrieve condition type from ifelseState if there exist conditions; else use AND type as default
   const initialConditionType: ConditionType =
     ifelseState.conditions.length > 0 ? ifelseState.conditions[0].type : 'AND'
@@ -148,156 +150,118 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   }
 
   return (
-    <VStack w="100%" align="stretch" spacing={6}>
-      <HStack w="100%" alignItems="flex-start">
-        <Box fontSize="20px" pt={2}>
-          <BiGitBranch />
-        </Box>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiGitBranch />}
+        />
         <Input
           name="title"
+          sx={commonStyles.fieldInput}
           type="text"
           placeholder="Result description"
           onChange={handleChange}
           value={title}
         />
+      </InputGroup>
+      <HStack sx={styles.inputContainer}>
+        <Text sx={styles.inputLabel}>IF</Text>
+        <ExpressionInput
+          type="text"
+          sx={commonStyles.expressionInput}
+          name="ifExpr"
+          onChange={(expr) => handleExprChange('ifExpr', expr)}
+          value={ifelseState.ifExpr}
+        />
+        <Box sx={styles.deleteSpacer} />
       </HStack>
-      <VStack align="stretch" spacing={4}>
-        <HStack align="start">
-          <Box w="100px" pl={8}>
-            <Heading as="h5" size="sm" lineHeight="40px">
-              IF
-            </Heading>
-          </Box>
-          <ExpressionInput
-            type="text"
-            name="ifExpr"
-            fontFamily="mono"
-            onChange={(expr) => handleExprChange('ifExpr', expr)}
-            value={ifelseState.ifExpr}
-          />
-          <HStack>
-            <DefaultTooltip label="Add condition" placement="right">
-              <IconButton
-                variant="ghost"
-                aria-label="Add condition"
-                fontSize="20px"
-                onClick={addCondition}
-                icon={<BiPlusCircle />}
-              />
-            </DefaultTooltip>
-          </HStack>
-        </HStack>
-        {ifelseState.conditions.map((cond, i) => (
-          <HStack key={i} align="start">
+      {ifelseState.conditions.map((cond, i) => (
+        <HStack key={i} sx={styles.inputContainer}>
+          {i === 0 ? (
             <Menu autoSelect={false}>
-              {i === 0 ? (
-                <Box w="100px">
-                  <MenuButton
-                    as={Button}
-                    variant="outline"
-                    rightIcon={<BiChevronDown />}
-                  >
-                    {conditionType}
-                  </MenuButton>
-                </Box>
-              ) : (
-                <Box w="100px" pl={4}>
-                  <Heading as="h5" size="sm" lineHeight="40px">
-                    {conditionType}
-                  </Heading>
-                </Box>
-              )}
-              <MenuList width="50px">
+              <MenuButton
+                as={Button}
+                variant="outline"
+                sx={styles.menuButton}
+                rightIcon={<BiChevronDown />}
+              >
+                {conditionType}
+              </MenuButton>
+              <MenuList sx={styles.menuList}>
                 <MenuItem
                   as={Button}
-                  borderRadius="0"
-                  fontWeight="normal"
-                  textAlign="start"
-                  justifyContent="initial"
-                  height="36px"
-                  isActive={conditionType === 'AND'}
                   variant="ghost"
+                  sx={styles.menuItem}
+                  isActive={conditionType === 'AND'}
                   onClick={() => updateAllConditionTypes('AND')}
                 >
-                  AND
+                  And
                 </MenuItem>
                 <MenuItem
                   as={Button}
-                  borderRadius={0}
-                  fontWeight="normal"
-                  textAlign="start"
-                  justifyContent="initial"
-                  height="36px"
-                  isActive={conditionType === 'OR'}
                   variant="ghost"
+                  sx={styles.menuItem}
+                  isActive={conditionType === 'OR'}
                   onClick={() => updateAllConditionTypes('OR')}
                 >
-                  OR
+                  Or
                 </MenuItem>
               </MenuList>
             </Menu>
-            <ExpressionInput
-              type="text"
-              fontFamily="mono"
-              onChange={(expression) =>
-                updateConditionExpression(i, { expression })
-              }
-              value={cond.expression}
+          ) : (
+            <Text sx={styles.spacedInputLabel}>{conditionType}</Text>
+          )}
+          <ExpressionInput
+            type="text"
+            sx={commonStyles.expressionInput}
+            onChange={(expression) =>
+              updateConditionExpression(i, { expression })
+            }
+            value={cond.expression}
+          />
+          <DefaultTooltip label="Delete condition">
+            <IconButton
+              variant="ghost"
+              sx={styles.deleteButton}
+              aria-label="Delete condition"
+              onClick={() => deleteCondition(i)}
+              icon={<BiTrash />}
             />
-            <HStack>
-              <DefaultTooltip label="Delete condition">
-                <IconButton
-                  variant="ghost"
-                  aria-label="Delete condition"
-                  fontSize="20px"
-                  onClick={() => deleteCondition(i)}
-                  icon={<BiTrash />}
-                />
-              </DefaultTooltip>
-              <DefaultTooltip label="Add condition" placement="right">
-                <IconButton
-                  variant="ghost"
-                  aria-label="Add condition"
-                  fontSize="20px"
-                  onClick={addCondition}
-                  icon={<BiPlusCircle />}
-                />
-              </DefaultTooltip>
-            </HStack>
-          </HStack>
-        ))}
-      </VStack>
-      <Divider />
-      <VStack align="stretch" spacing={4}>
-        <HStack align="start">
-          <Box w="100px" pl={8}>
-            <Heading as="h5" size="sm" lineHeight="40px">
-              THEN
-            </Heading>
-          </Box>
-          <ExpressionInput
-            type="text"
-            name="thenExpr"
-            fontFamily="mono"
-            onChange={(expr) => handleExprChange('thenExpr', expr)}
-            value={ifelseState.thenExpr}
-          />
+          </DefaultTooltip>
         </HStack>
-        <HStack align="start">
-          <Box w="100px" pl={8}>
-            <Heading as="h5" size="sm" lineHeight="40px">
-              ELSE
-            </Heading>
-          </Box>
-          <ExpressionInput
-            type="text"
-            name="elseExpr"
-            fontFamily="mono"
-            onChange={(expr) => handleExprChange('elseExpr', expr)}
-            value={ifelseState.elseExpr}
-          />
-        </HStack>
-      </VStack>
+      ))}
+      <Button
+        variant="solid"
+        sx={styles.addButton}
+        colorScheme="primary"
+        aria-label="Add condition"
+        onClick={addCondition}
+        leftIcon={<BiPlus />}
+      >
+        Add New
+      </Button>
+      <Divider sx={styles.divider} />
+      <HStack sx={styles.inputContainer}>
+        <Text sx={styles.inputLabel}>THEN</Text>
+        <ExpressionInput
+          type="text"
+          sx={commonStyles.expressionInput}
+          name="thenExpr"
+          onChange={(expr) => handleExprChange('thenExpr', expr)}
+          value={ifelseState.thenExpr}
+        />
+      </HStack>
+      <HStack sx={styles.inputContainer}>
+        <Text sx={styles.inputLabel}>ELSE</Text>
+        <ExpressionInput
+          type="text"
+          sx={commonStyles.expressionInput}
+          name="elseExpr"
+          onChange={(expr) => handleExprChange('elseExpr', expr)}
+          value={ifelseState.elseExpr}
+        />
+      </HStack>
     </VStack>
   )
 }

--- a/src/client/components/builder/logic/DateResult.tsx
+++ b/src/client/components/builder/logic/DateResult.tsx
@@ -137,35 +137,55 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
       </InputGroup>
       <HStack sx={styles.dateContainer} spacing={4}>
         <Menu matchWidth>
-          <MenuButton
-            as={Button}
-            sx={styles.questionButton}
-            variant="outline"
-            rightIcon={<BiChevronDown />}
-          >
-            <Text
-              sx={styles.menuButtonText}
-              textColor={dateState.variableId ? 'secondary.700' : 'neutral.500'}
-            >
-              {dateState.variableId ? dateState.variableId : 'Select question'}
-            </Text>
-          </MenuButton>
-          <MenuList>
-            {config.fields
-              .filter(({ type }) => type === 'DATE')
-              .map(({ id, title }, i) => (
-                <MenuItem key={i} onClick={() => updateState('variableId', id)}>
-                  {renderBadgeWithTitle(id, title, 'success.500')}
-                </MenuItem>
-              ))}
-            {config.operations
-              .filter(({ id, type }) => type === 'DATE' && id !== currentId)
-              .map(({ id, title }, i) => (
-                <MenuItem key={i} onClick={() => updateState('variableId', id)}>
-                  {renderBadgeWithTitle(id, title, 'primary.500')}
-                </MenuItem>
-              ))}
-          </MenuList>
+          {({ onClose }) => (
+            <>
+              <MenuButton
+                as={Button}
+                sx={styles.questionButton}
+                variant="outline"
+                rightIcon={<BiChevronDown />}
+              >
+                <Text
+                  sx={styles.menuButtonText}
+                  textColor={
+                    dateState.variableId ? 'secondary.700' : 'neutral.500'
+                  }
+                >
+                  {dateState.variableId
+                    ? dateState.variableId
+                    : 'Select question'}
+                </Text>
+              </MenuButton>
+              <MenuList>
+                {config.fields
+                  .filter(({ type }) => type === 'DATE')
+                  .map(({ id, title }, i) => (
+                    <MenuItem
+                      key={i}
+                      onClick={() => {
+                        updateState('variableId', id)
+                        onClose()
+                      }}
+                    >
+                      {renderBadgeWithTitle(id, title, 'success.500')}
+                    </MenuItem>
+                  ))}
+                {config.operations
+                  .filter(({ id, type }) => type === 'DATE' && id !== currentId)
+                  .map(({ id, title }, i) => (
+                    <MenuItem
+                      key={i}
+                      onClick={() => {
+                        updateState('variableId', id)
+                        onClose()
+                      }}
+                    >
+                      {renderBadgeWithTitle(id, title, 'primary.500')}
+                    </MenuItem>
+                  ))}
+              </MenuList>
+            </>
+          )}
         </Menu>
         <Menu matchWidth>
           <MenuButton

--- a/src/client/components/builder/logic/DateResult.tsx
+++ b/src/client/components/builder/logic/DateResult.tsx
@@ -4,7 +4,6 @@ import { BiCalendar, BiChevronDown } from 'react-icons/bi'
 import {
   VStack,
   HStack,
-  Box,
   Text,
   Input,
   Badge,
@@ -15,6 +14,10 @@ import {
   MenuList,
   NumberInput,
   NumberInputField,
+  InputGroup,
+  InputLeftElement,
+  useStyles,
+  useMultiStyleConfig,
 } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
@@ -63,6 +66,9 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
     fromExpression(expression)
   )
 
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('DateResult', {})
+
   useEffect(() => {
     const updatedExpression = toExpression(dateState)
     if (
@@ -100,91 +106,96 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
     )
   }
 
+  const renderBadgeWithTitle = (
+    id: string,
+    title: string,
+    badgeCol: string
+  ) => (
+    <HStack sx={styles.menuRowContainer} spacing={4}>
+      <Badge sx={styles.menuRowBadge} bg={badgeCol}>
+        {id}
+      </Badge>
+      <Text isTruncated>{title}</Text>
+    </HStack>
+  )
+
   return (
-    <HStack w="100%" alignItems="flex-start">
-      <Box fontSize="20px" pt={2}>
-        <BiCalendar />
-      </Box>
-      <VStack align="stretch" w="100%">
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiCalendar />}
+        />
         <Input
           name="title"
+          sx={commonStyles.fieldInput}
           type="text"
           placeholder="Operation title"
           onChange={handleChange}
           value={title}
         />
-        <HStack>
-          <Menu>
-            <MenuButton as={Button} rightIcon={<BiChevronDown />}>
-              {dateState.variableId ? dateState.variableId : 'SELECT INPUT'}
-            </MenuButton>
-            <MenuList>
-              {config.fields
-                .filter(({ type }) => type === 'DATE')
-                .map(({ id, title }, i) => (
-                  <MenuItem
-                    key={i}
-                    onClick={() => updateState('variableId', id)}
-                  >
-                    <HStack spacing={4}>
-                      <Badge
-                        bg="error.500"
-                        color="white"
-                        fontSize="sm"
-                        borderRadius="5px"
-                      >
-                        {id}
-                      </Badge>
-                      <Text isTruncated>{title}</Text>
-                    </HStack>
-                  </MenuItem>
-                ))}
-              {config.operations
-                .filter(({ id, type }) => type === 'DATE' && id !== currentId)
-                .map(({ id, title }, i) => (
-                  <MenuItem
-                    key={i}
-                    onClick={() => updateState('variableId', id)}
-                  >
-                    <HStack spacing={4}>
-                      <Badge
-                        bg="success.500"
-                        color="white"
-                        fontSize="sm"
-                        borderRadius="5px"
-                      >
-                        {id}
-                      </Badge>
-                      <Text isTruncated>{title}</Text>
-                    </HStack>
-                  </MenuItem>
-                ))}
-            </MenuList>
-          </Menu>
-          <Menu>
-            <MenuButton as={Button} rightIcon={<BiChevronDown />}>
-              {dateState.isAdd ? '+' : '-'}
-            </MenuButton>
-            <MenuList>
-              <MenuItem onClick={() => updateState('isAdd', true)}>+</MenuItem>
-              <MenuItem onClick={() => updateState('isAdd', false)}>-</MenuItem>
-            </MenuList>
-          </Menu>
-          <NumberInput
-            precision={0}
-            step={1}
-            min={0}
-            defaultValue={
-              dateState.numberOfIntervals && dateState.numberOfIntervals
-            }
-            onChange={(value) => updateState('numberOfIntervals', value)}
+      </InputGroup>
+      <HStack sx={styles.dateContainer} spacing={4}>
+        <Menu matchWidth>
+          <MenuButton
+            as={Button}
+            sx={styles.questionButton}
+            variant="outline"
+            rightIcon={<BiChevronDown />}
           >
-            <NumberInputField placeholder="Number" />
-          </NumberInput>
-          <Text>days</Text>
-        </HStack>
-      </VStack>
-    </HStack>
+            <Text
+              sx={styles.menuButtonText}
+              textColor={dateState.variableId ? 'secondary.700' : 'neutral.500'}
+            >
+              {dateState.variableId ? dateState.variableId : 'Select question'}
+            </Text>
+          </MenuButton>
+          <MenuList>
+            {config.fields
+              .filter(({ type }) => type === 'DATE')
+              .map(({ id, title }, i) => (
+                <MenuItem key={i} onClick={() => updateState('variableId', id)}>
+                  {renderBadgeWithTitle(id, title, 'success.500')}
+                </MenuItem>
+              ))}
+            {config.operations
+              .filter(({ id, type }) => type === 'DATE' && id !== currentId)
+              .map(({ id, title }, i) => (
+                <MenuItem key={i} onClick={() => updateState('variableId', id)}>
+                  {renderBadgeWithTitle(id, title, 'primary.500')}
+                </MenuItem>
+              ))}
+          </MenuList>
+        </Menu>
+        <Menu matchWidth>
+          <MenuButton
+            as={Button}
+            sx={styles.operatorButton}
+            variant="outline"
+            rightIcon={<BiChevronDown />}
+          >
+            <Text sx={styles.menuButtonText}>
+              {dateState.isAdd ? '+' : '-'}
+            </Text>
+          </MenuButton>
+          <MenuList sx={styles.operatorMenuList}>
+            <MenuItem onClick={() => updateState('isAdd', true)}>+</MenuItem>
+            <MenuItem onClick={() => updateState('isAdd', false)}>-</MenuItem>
+          </MenuList>
+        </Menu>
+        <NumberInput
+          sx={styles.numberInput}
+          precision={0}
+          step={1}
+          min={0}
+          defaultValue={dateState.numberOfIntervals || undefined}
+          onChange={(value) => updateState('numberOfIntervals', value)}
+        >
+          <NumberInputField sx={styles.numberField} placeholder="Number" />
+        </NumberInput>
+        <Text sx={styles.daysText}>DAYS</Text>
+      </HStack>
+    </VStack>
   )
 }
 

--- a/src/client/components/builder/logic/FormulaPreview.tsx
+++ b/src/client/components/builder/logic/FormulaPreview.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import { IconType } from 'react-icons'
-import { VStack, HStack, Text } from '@chakra-ui/react'
+import { VStack, HStack, Text, useStyles } from '@chakra-ui/react'
 
 interface FormulaPreviewProps {
   show: boolean
@@ -15,13 +15,19 @@ export const FormulaPreview: FC<FormulaPreviewProps> = ({
   expression,
   icon: Icon,
 }) => {
+  const commonStyles = useStyles()
+
   return (
-    <VStack align="stretch" w="50%" spacing={4} opacity={show ? 1 : 0.5}>
+    <VStack
+      sx={commonStyles.fullWidthContainer}
+      spacing={4}
+      opacity={show ? 1 : 0.5}
+    >
       <HStack>
-        <Icon fontSize="20px" />
-        <Text>{title}</Text>
+        <Icon fontSize="16px" />
+        <Text sx={commonStyles.previewTitle}>{title}</Text>
       </HStack>
-      <Text fontFamily="mono">{expression}</Text>
+      <Text sx={commonStyles.expressionInput}>{expression}</Text>
     </VStack>
   )
 }

--- a/src/client/components/builder/logic/MapResult.tsx
+++ b/src/client/components/builder/logic/MapResult.tsx
@@ -138,60 +138,86 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
       <HStack sx={styles.mapContainer} spacing={4}>
         <Text sx={styles.mapText}>MAP</Text>
         <Menu matchWidth preventOverflow={false}>
-          <MenuButton
-            as={Button}
-            sx={styles.menuButton}
-            variant="outline"
-            rightIcon={<BiChevronDown />}
-          >
-            <Text
-              sx={styles.menuButtonText}
-              textColor={mapState.variableId ? 'secondary.700' : 'neutral.500'}
-            >
-              {mapState.variableId ? mapState.variableId : 'Select question'}
-            </Text>
-          </MenuButton>
-          <MenuList sx={styles.menuList}>
-            {config.fields.map(({ id, title }, i) => (
-              <MenuItem
-                key={i}
-                onClick={() => handleExprChange('variableId', id)}
+          {({ onClose }) => (
+            <>
+              <MenuButton
+                as={Button}
+                sx={styles.menuButton}
+                variant="outline"
+                rightIcon={<BiChevronDown />}
               >
-                {renderBadgeWithTitle(id, title, 'error.500')}
-              </MenuItem>
-            ))}
-            {config.operations.map(({ id, title }, i) => (
-              <MenuItem
-                key={i}
-                onClick={() => handleExprChange('variableId', id)}
-              >
-                {renderBadgeWithTitle(id, title, 'success.500')}
-              </MenuItem>
-            ))}
-          </MenuList>
+                <Text
+                  sx={styles.menuButtonText}
+                  textColor={
+                    mapState.variableId ? 'secondary.700' : 'neutral.500'
+                  }
+                >
+                  {mapState.variableId
+                    ? mapState.variableId
+                    : 'Select question'}
+                </Text>
+              </MenuButton>
+              <MenuList sx={styles.menuList}>
+                {config.fields.map(({ id, title }, i) => (
+                  <MenuItem
+                    key={i}
+                    onClick={() => {
+                      handleExprChange('variableId', id)
+                      onClose()
+                    }}
+                  >
+                    {renderBadgeWithTitle(id, title, 'error.500')}
+                  </MenuItem>
+                ))}
+                {config.operations.map(({ id, title }, i) => (
+                  <MenuItem
+                    key={i}
+                    onClick={() => {
+                      handleExprChange('variableId', id)
+                      onClose()
+                    }}
+                  >
+                    {renderBadgeWithTitle(id, title, 'success.500')}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </>
+          )}
         </Menu>
         <Text sx={styles.toText}>TO</Text>
         <Menu matchWidth>
-          <MenuButton
-            as={Button}
-            sx={styles.menuButton}
-            variant="outline"
-            rightIcon={<BiChevronDown />}
-          >
-            <Text
-              sx={styles.menuButtonText}
-              textColor={mapState.tableId ? 'secondary.700' : 'neutral.500'}
-            >
-              {mapState.tableId ? mapState.tableId : 'Select constant table'}
-            </Text>
-          </MenuButton>
-          <MenuList sx={styles.menuList}>
-            {config.constants.map(({ id, title }, i) => (
-              <MenuItem key={i} onClick={() => handleExprChange('tableId', id)}>
-                {renderBadgeWithTitle(id, title, 'warning.500')}
-              </MenuItem>
-            ))}
-          </MenuList>
+          {({ onClose }) => (
+            <>
+              <MenuButton
+                as={Button}
+                sx={styles.menuButton}
+                variant="outline"
+                rightIcon={<BiChevronDown />}
+              >
+                <Text
+                  sx={styles.menuButtonText}
+                  textColor={mapState.tableId ? 'secondary.700' : 'neutral.500'}
+                >
+                  {mapState.tableId
+                    ? mapState.tableId
+                    : 'Select constant table'}
+                </Text>
+              </MenuButton>
+              <MenuList sx={styles.menuList}>
+                {config.constants.map(({ id, title }, i) => (
+                  <MenuItem
+                    key={i}
+                    onClick={() => {
+                      handleExprChange('tableId', id)
+                      onClose()
+                    }}
+                  >
+                    {renderBadgeWithTitle(id, title, 'warning.500')}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </>
+          )}
         </Menu>
       </HStack>
     </VStack>

--- a/src/client/components/builder/logic/MapResult.tsx
+++ b/src/client/components/builder/logic/MapResult.tsx
@@ -5,16 +5,18 @@ import { BiGitCompare, BiChevronDown } from 'react-icons/bi'
 import {
   Badge,
   Button,
-  Heading,
   VStack,
   HStack,
-  Box,
   Text,
   Input,
   Menu,
   MenuButton,
   MenuList,
   MenuItem,
+  InputGroup,
+  InputLeftElement,
+  useStyles,
+  useMultiStyleConfig,
 } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../../contexts'
@@ -63,6 +65,9 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
   const { config, dispatch } = useCheckerContext()
   const [mapState, setMapState] = useState<MapState>(fromExpression(expression))
 
+  const commonStyles = useStyles()
+  const styles = useMultiStyleConfig('MapResult', {})
+
   useEffect(() => {
     const updatedExpr = toExpression(mapState)
     // TODO: Check args length is 2
@@ -101,112 +106,94 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
     )
   }
 
+  const renderBadgeWithTitle = (
+    id: string,
+    title: string,
+    badgeCol: string
+  ) => (
+    <HStack sx={styles.menuRowContainer} spacing={4}>
+      <Badge sx={styles.menuRowBadge} bg={badgeCol}>
+        {id}
+      </Badge>
+      <Text isTruncated>{title}</Text>
+    </HStack>
+  )
+
   return (
-    <VStack w="100%" align="stretch" spacing={6}>
-      <HStack w="100%" alignItems="flex-start">
-        <Box fontSize="20px" pt={2}>
-          <BiGitCompare />
-        </Box>
+    <VStack sx={commonStyles.fullWidthContainer} spacing={4}>
+      <InputGroup>
+        <InputLeftElement
+          sx={commonStyles.inputIconElement}
+          children={<BiGitCompare />}
+        />
         <Input
           name="title"
+          sx={commonStyles.fieldInput}
           type="text"
           placeholder="Result description"
           onChange={handleChange}
           value={title}
         />
+      </InputGroup>
+      <HStack sx={styles.mapContainer} spacing={4}>
+        <Text sx={styles.mapText}>MAP</Text>
+        <Menu matchWidth preventOverflow={false}>
+          <MenuButton
+            as={Button}
+            sx={styles.menuButton}
+            variant="outline"
+            rightIcon={<BiChevronDown />}
+          >
+            <Text
+              sx={styles.menuButtonText}
+              textColor={mapState.variableId ? 'secondary.700' : 'neutral.500'}
+            >
+              {mapState.variableId ? mapState.variableId : 'Select question'}
+            </Text>
+          </MenuButton>
+          <MenuList sx={styles.menuList}>
+            {config.fields.map(({ id, title }, i) => (
+              <MenuItem
+                key={i}
+                onClick={() => handleExprChange('variableId', id)}
+              >
+                {renderBadgeWithTitle(id, title, 'error.500')}
+              </MenuItem>
+            ))}
+            {config.operations.map(({ id, title }, i) => (
+              <MenuItem
+                key={i}
+                onClick={() => handleExprChange('variableId', id)}
+              >
+                {renderBadgeWithTitle(id, title, 'success.500')}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Menu>
+        <Text sx={styles.toText}>TO</Text>
+        <Menu matchWidth>
+          <MenuButton
+            as={Button}
+            sx={styles.menuButton}
+            variant="outline"
+            rightIcon={<BiChevronDown />}
+          >
+            <Text
+              sx={styles.menuButtonText}
+              textColor={mapState.tableId ? 'secondary.700' : 'neutral.500'}
+            >
+              {mapState.tableId ? mapState.tableId : 'Select constant table'}
+            </Text>
+          </MenuButton>
+          <MenuList sx={styles.menuList}>
+            {config.constants.map(({ id, title }, i) => (
+              <MenuItem key={i} onClick={() => handleExprChange('tableId', id)}>
+                {renderBadgeWithTitle(id, title, 'warning.500')}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Menu>
       </HStack>
-      <VStack align="stretch" spacing={4}>
-        <HStack>
-          <Box w="100px" pl={8}>
-            <Heading as="h5" size="sm">
-              MAP
-            </Heading>
-          </Box>
-          <Menu>
-            <MenuButton
-              as={Button}
-              variant="outline"
-              rightIcon={<BiChevronDown />}
-            >
-              {mapState.variableId ? mapState.variableId : 'SELECT INPUT'}
-            </MenuButton>
-            <MenuList>
-              {config.fields.map(({ id, title }, i) => (
-                <MenuItem
-                  key={i}
-                  onClick={() => handleExprChange('variableId', id)}
-                >
-                  <HStack spacing={4}>
-                    <Badge
-                      bg="error.500"
-                      color="white"
-                      fontSize="sm"
-                      borderRadius="5px"
-                    >
-                      {id}
-                    </Badge>
-                    <Text isTruncated>{title}</Text>
-                  </HStack>
-                </MenuItem>
-              ))}
-              {config.operations.map(({ id, title }, i) => (
-                <MenuItem
-                  key={i}
-                  onClick={() => handleExprChange('variableId', id)}
-                >
-                  <HStack spacing={4}>
-                    <Badge
-                      bg="success.500"
-                      color="white"
-                      fontSize="sm"
-                      borderRadius="5px"
-                    >
-                      {id}
-                    </Badge>
-                    <Text isTruncated>{title}</Text>
-                  </HStack>
-                </MenuItem>
-              ))}
-            </MenuList>
-          </Menu>
-        </HStack>
-        <HStack>
-          <Box w="100px" pl={8}>
-            <Heading as="h5" size="sm">
-              TO
-            </Heading>
-          </Box>
-          <Menu>
-            <MenuButton
-              as={Button}
-              variant="outline"
-              rightIcon={<BiChevronDown />}
-            >
-              {mapState.tableId ? mapState.tableId : 'SELECT MAP TABLE'}
-            </MenuButton>
-            <MenuList>
-              {config.constants.map(({ id, title }, i) => (
-                <MenuItem
-                  key={i}
-                  onClick={() => handleExprChange('tableId', id)}
-                >
-                  <HStack spacing={4}>
-                    <Badge
-                      bg="primary.500"
-                      color="white"
-                      fontSize="sm"
-                      borderRadius="5px"
-                    >
-                      {id}
-                    </Badge>
-                    <Text isTruncated>{title}</Text>
-                  </HStack>
-                </MenuItem>
-              ))}
-            </MenuList>
-          </Menu>
-        </HStack>
-      </VStack>
     </VStack>
   )
 }

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -85,6 +85,12 @@ export const BuilderField: ComponentMultiStyleConfig = {
     barSpacer: {
       h: 2,
     },
+    logicCaption: {
+      pl: 2,
+      color: 'neutral.500',
+      textStyle: 'caption1',
+      fontStyle: 'italic',
+    },
     ...CommonComponents.baseStyle,
   },
   variants: {

--- a/src/client/theme/components/builder/BuilderField.tsx
+++ b/src/client/theme/components/builder/BuilderField.tsx
@@ -4,6 +4,7 @@ const CommonComponents: ComponentMultiStyleConfig = {
   parts: [
     'dummyInput',
     'fieldInput',
+    'expressionInput',
     'inputIconElement',
     'fullWidthContainer',
     'halfWidthContainer',
@@ -20,6 +21,9 @@ const CommonComponents: ComponentMultiStyleConfig = {
     },
     fieldInput: {
       textStyle: 'body1',
+    },
+    expressionInput: {
+      fontFamily: 'mono',
     },
     inputIconElement: {
       pointerEvents: 'none',

--- a/src/client/theme/components/builder/index.ts
+++ b/src/client/theme/components/builder/index.ts
@@ -2,10 +2,12 @@ import { BuilderField } from './BuilderField'
 import { ActionButton } from './ActionButton'
 import { questions } from './questions'
 import { constants } from './constants'
+import { logic } from './logic'
 
 export const builder = {
   BuilderField,
   ActionButton,
   ...questions,
   ...constants,
+  ...logic,
 }

--- a/src/client/theme/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/theme/components/builder/logic/ConditionalResult.tsx
@@ -1,0 +1,78 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const ConditionalResult: ComponentMultiStyleConfig = {
+  parts: [
+    'inputLabel',
+    'spacedInputLabel',
+    'inputContainer',
+    'menuButton',
+    'menuList',
+    'menuItem',
+    'deleteSpacer',
+    'deleteButton',
+    'addButton',
+    'divider',
+  ],
+  baseStyle: {
+    inputLabel: {
+      w: '48px',
+      mr: 2,
+      textStyle: 'subhead3',
+      lineHeight: '40px',
+    },
+    spacedInputLabel: {
+      w: '96px',
+      mr: 2,
+      textStyle: 'subhead3',
+      lineHeight: '40px',
+    },
+    inputContainer: {
+      alignItems: 'start',
+    },
+    menuButton: {
+      w: '96px',
+      mr: 2,
+      textStyle: 'subhead3',
+      fontSize: '14px',
+      borderRadius: '3px',
+    },
+    menuList: {
+      borderRadius: '3px',
+      minW: '160px',
+      py: 3,
+    },
+    menuItem: {
+      borderRadius: 0,
+      px: 5,
+      py: 3,
+      textStyle: 'body1',
+      textAlign: 'start',
+      justifyContent: 'initial',
+      height: '48px',
+    },
+    deleteSpacer: {
+      w: '40px',
+    },
+    deleteButton: {
+      color: 'error.500',
+      borderRadius: '3px',
+      fontSize: '20px',
+    },
+    addButton: {
+      textStyle: 'subhead1',
+      fontWeight: '500',
+      w: 'fit-content',
+      h: '44px',
+      borderRadius: '3px',
+    },
+    divider: {
+      // !important is required to break out of chakra's stack selectors
+      // refer to https://github.com/chakra-ui/chakra-ui/issues/2476
+      ml: '-24px !important',
+      mr: '-32px !important',
+      mt: '24px !important',
+      mb: '8px !important',
+      w: 'auto',
+    },
+  },
+}

--- a/src/client/theme/components/builder/logic/DateResult.tsx
+++ b/src/client/theme/components/builder/logic/DateResult.tsx
@@ -1,0 +1,53 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const DateResult: ComponentMultiStyleConfig = {
+  parts: [
+    'dateContainer',
+    'questionButton',
+    'operatorButton',
+    'operatorMenuList',
+    'menuButtonText',
+    'menuRowContainer',
+    'menuRowBadge',
+    'numberInput',
+    'numberField',
+    'daysText',
+  ],
+  baseStyle: {
+    dateContainer: {
+      justify: 'stretch',
+    },
+    questionButton: {
+      w: '100%',
+    },
+    operatorButton: {
+      w: '80px',
+      flexShrink: 0,
+    },
+    operatorMenuList: {
+      minW: '80px',
+    },
+    menuButtonText: {
+      textAlign: 'left',
+      textStyle: 'body1',
+    },
+    menuRowContainer: {
+      w: 'inherit',
+    },
+    menuRowBadge: {
+      color: 'white',
+      fontSize: 'sm',
+      borderRadius: '3px',
+    },
+    numberInput: {
+      w: '96px',
+      flexShrink: 0,
+    },
+    numberField: {
+      paddingInline: 4,
+    },
+    daysText: {
+      textStyle: 'subhead3',
+    },
+  },
+}

--- a/src/client/theme/components/builder/logic/MapResult.tsx
+++ b/src/client/theme/components/builder/logic/MapResult.tsx
@@ -1,0 +1,48 @@
+import { ComponentMultiStyleConfig } from '@chakra-ui/theme'
+
+export const MapResult: ComponentMultiStyleConfig = {
+  parts: [
+    'mapContainer',
+    'mapText',
+    'menuButton',
+    'menuButtonText',
+    'menuList',
+    'menuRowContainer',
+    'menuRowBadge',
+    'toText',
+  ],
+  baseStyle: {
+    mapContainer: {
+      justify: 'stretch',
+    },
+    mapText: {
+      w: '48px',
+      textStyle: 'subhead3',
+      flexShrink: 0,
+    },
+    menuButton: {
+      w: '50%',
+    },
+    menuButtonText: {
+      textStyle: 'body1',
+      textAlign: 'left',
+    },
+    menuList: {
+      w: 'inherit',
+    },
+    menuRowContainer: {
+      w: 'inherit',
+    },
+    menuRowBadge: {
+      color: 'white',
+      fontSize: 'sm',
+      borderRadius: '3px',
+    },
+    toText: {
+      w: '48px',
+      textAlign: 'center',
+      textStyle: 'subhead3',
+      flexShrink: 0,
+    },
+  },
+}

--- a/src/client/theme/components/builder/logic/index.ts
+++ b/src/client/theme/components/builder/logic/index.ts
@@ -1,7 +1,9 @@
 import { ConditionalResult } from './ConditionalResult'
 import { MapResult } from './MapResult'
+import { DateResult } from './DateResult'
 
 export const logic = {
   ConditionalResult,
   MapResult,
+  DateResult,
 }

--- a/src/client/theme/components/builder/logic/index.ts
+++ b/src/client/theme/components/builder/logic/index.ts
@@ -1,5 +1,7 @@
 import { ConditionalResult } from './ConditionalResult'
+import { MapResult } from './MapResult'
 
 export const logic = {
   ConditionalResult,
+  MapResult,
 }

--- a/src/client/theme/components/builder/logic/index.ts
+++ b/src/client/theme/components/builder/logic/index.ts
@@ -1,0 +1,5 @@
+import { ConditionalResult } from './ConditionalResult'
+
+export const logic = {
+  ConditionalResult,
+}


### PR DESCRIPTION
## Problem

Update the `CalculatedField`, `ConditionalField`, `MapResult`, `DateResult` and `FormulaPreview` component styles to align with the new design system.

Part of #549

## Solution

**Improvements**:

- updated text styles
- added shared styles for expression inputs
- updated and simplified layout
- added folder for logic field specific styles
- added additional field-specific styles in a separate theme file

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-06-08 at 11 57 02 AM](https://user-images.githubusercontent.com/21305518/121120694-a79daf00-c850-11eb-91c9-2d01da016aad.png)

**AFTER**:
![Screenshot 2021-06-08 at 11 53 48 AM](https://user-images.githubusercontent.com/21305518/121120702-ae2c2680-c850-11eb-94b0-8093bf993ce4.png)

## Tests

- [ ] Check that the new component styles line up with the design system
