### PR TITLE
feat(builder-blocks): update copy

### DIFF
--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -90,7 +90,7 @@ export const LogicTab: FC = () => {
 
   const addMenu = [
     {
-      label: 'Calculated result',
+      label: 'Calculation',
       icon: <BiCalculator />,
       onClick: () => {
         dispatch({
@@ -106,7 +106,7 @@ export const LogicTab: FC = () => {
       },
     },
     {
-      label: 'Conditional result',
+      label: 'Conditional',
       icon: <BiGitBranch />,
       onClick: () => {
         dispatch({
@@ -122,7 +122,7 @@ export const LogicTab: FC = () => {
       },
     },
     {
-      label: 'Map constant',
+      label: 'Map constants',
       icon: <BiGitCompare />,
       disabled: config.constants.length === 0,
       onClick: () => {
@@ -139,7 +139,7 @@ export const LogicTab: FC = () => {
       },
     },
     {
-      label: 'Date result',
+      label: 'Date calculation',
       icon: <BiCalendar />,
       onClick: () => {
         dispatch({

--- a/src/client/components/builder/QuestionsTab.tsx
+++ b/src/client/components/builder/QuestionsTab.tsx
@@ -122,7 +122,7 @@ export const QuestionsTab: FC = () => {
       label: 'Add question',
       menu: [
         {
-          label: 'Numeric field',
+          label: 'Number',
           icon: <BiHash />,
           onClick: () => {
             dispatch({
@@ -154,7 +154,7 @@ export const QuestionsTab: FC = () => {
           },
         },
         {
-          label: 'Dropdown List',
+          label: 'Dropdown',
           icon: <IoIosArrowDropdown />,
           onClick: () => {
             dispatch({

--- a/src/client/components/builder/logic/CalculatedResult.tsx
+++ b/src/client/components/builder/logic/CalculatedResult.tsx
@@ -64,7 +64,6 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           name="expression"
           sx={commonStyles.expressionInput}
           type="text"
-          placeholder="Enter formula"
           value={expression}
           onChange={(expression) =>
             handleExpressionChange('expression', expression)

--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -248,6 +248,7 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           type="text"
           sx={commonStyles.expressionInput}
           name="thenExpr"
+          placeholder="Use this field as a ‘true/false’ statement, or show a result"
           onChange={(expr) => handleExprChange('thenExpr', expr)}
           value={ifelseState.thenExpr}
         />
@@ -258,6 +259,7 @@ const InputComponent: OperationFieldComponent = ({ operation, index }) => {
           type="text"
           sx={commonStyles.expressionInput}
           name="elseExpr"
+          placeholder="Use this field as a ‘true/false’ statement, or show a result"
           onChange={(expr) => handleExprChange('elseExpr', expr)}
           value={ifelseState.elseExpr}
         />

--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -49,6 +49,7 @@ interface ExpressionInputProps extends Omit<InputProps, 'onChange' | 'value'> {
 export const ExpressionInput: FC<ExpressionInputProps> = ({
   onChange,
   value,
+  placeholder,
   ...props
 }) => {
   const [inputValue, setInputValue] = useState<string>(value)
@@ -264,6 +265,8 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
           >
             <Input
               {...getInputProps({
+                placeholder:
+                  placeholder || 'Type @ to reference a block in your formula',
                 ...props,
               })}
               value={inputValue || ''}


### PR DESCRIPTION
## Problem

Update floating toolbar button copy, logic field expression input placeholder copy to align to design system, and also clarify the use of the `@` operator

Part of #549, closes #620

## Solution

**Improvements**:

- update copy for add block menu buttons
- add default placeholder for expression inputs
- update placeholders for `CalculatedResult` and `ConditionalResult` fields

## Before & After Screenshots

**BEFORE**:
<img width="207" alt="Screenshot 2021-06-08 at 4 13 16 PM" src="https://user-images.githubusercontent.com/21305518/121148920-c6ae3800-c874-11eb-9390-dac4bd54e19c.png">
<img width="829" alt="Screenshot 2021-06-08 at 4 12 55 PM" src="https://user-images.githubusercontent.com/21305518/121148928-c7df6500-c874-11eb-96fb-0c3701e2ea9e.png">
<img width="1099" alt="Screenshot 2021-06-08 at 4 12 46 PM" src="https://user-images.githubusercontent.com/21305518/121148935-c9a92880-c874-11eb-8912-1c69546eb952.png">

**AFTER**:
<img width="208" alt="Screenshot 2021-06-08 at 4 07 12 PM" src="https://user-images.githubusercontent.com/21305518/121149007-db8acb80-c874-11eb-8f92-34b9a915cc1a.png">
<img width="825" alt="Screenshot 2021-06-08 at 4 06 55 PM" src="https://user-images.githubusercontent.com/21305518/121149011-dcbbf880-c874-11eb-87ac-850aab4bb7c9.png">
<img width="1098" alt="Screenshot 2021-06-08 at 4 06 42 PM" src="https://user-images.githubusercontent.com/21305518/121149019-dded2580-c874-11eb-94f0-6906513582b9.png">


## Tests

- [ ] Check that new add menu button copy aligns with design system