### PR TITLE
fix(checker): improve field null checks on checker submission

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -96,7 +96,7 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
 
     fields.forEach((field) => {
       const { id, type, options } = field
-      if (!inputs[id]) return
+      if (inputs[id] === null || inputs[id] === undefined) return
 
       switch (type) {
         case 'NUMERIC': {


### PR DESCRIPTION
## Problem

Improve null check within checker submission method to prevent erroneous coercion of `0` as a falsy value.

Closes #676

## Solution

**Bug Fixes**:

- improve null guard conditional in checker submission method

## Tests

1. Create a new numeric field
2. Use numeric field in a calculated result
3. Go to preview and submit (leaving value as 0)

- [ ] Check that submission works as expected, where the calculated field should use 0 as the result value.
