### PR TITLE
feat(line-display): add support for in-string hyperlink

### DIFF
--- a/src/client/components/displays/LineDisplay.tsx
+++ b/src/client/components/displays/LineDisplay.tsx
@@ -1,5 +1,6 @@
-import React, { FC } from 'react'
-import { Stack, Text, useMultiStyleConfig } from '@chakra-ui/react'
+import React, { FC, ReactNodeArray } from 'react'
+import { Icon, Link, Stack, Text, useMultiStyleConfig } from '@chakra-ui/react'
+import { BiLinkExternal } from 'react-icons/bi'
 
 // If the value is over this threshold, the result will be rendered as horizontal
 // regardless of whether it is in mobile view.
@@ -16,10 +17,48 @@ export const LineDisplay: FC<LineDisplayProps> = ({ label, value }) => {
     variant: isOverflow ? 'column' : 'base',
   })
 
+  const linkParser = (value: string) => {
+    const linkRegex = /link\(.*\)/g
+    const outputNode: ReactNodeArray = []
+    let lastStartIndex = 0
+    let keyIndex = 0
+
+    let match: RegExpExecArray | null
+    while ((match = linkRegex.exec(value)) !== null) {
+      // add regular text before any link matches
+      outputNode.push(value.slice(lastStartIndex, match.index))
+      lastStartIndex = match.index + match[0].length
+
+      const linkParams = match[0]
+        .slice(5, match[0].length - 1) // remove 'link(' and ')'
+        .split(',') // split params
+        .map((str) => str.trim().replace(/['"]/g, '')) // remove string quotes from params
+
+      // turn incomplete links into valid ones (e.g 'www.google.com')
+      const getValidLink = (link: string) => {
+        if (!link.startsWith('https://') && !link.startsWith('http://')) {
+          return `https://${link}`
+        }
+
+        return link
+      }
+
+      outputNode.push(
+        <Link key={keyIndex++} href={getValidLink(linkParams[1])} isExternal>
+          {linkParams[0]} <Icon as={BiLinkExternal} sx={styles.hyperlinkIcon} />
+        </Link>
+      )
+    }
+    // add text after links (if it exists)
+    outputNode.push(value.slice(lastStartIndex))
+
+    return outputNode
+  }
+
   return (
     <Stack sx={styles.container} spacing="8px">
       <Text sx={styles.label}>{label}</Text>
-      <Text sx={styles.value}>{value}</Text>
+      <Text sx={styles.value}>{linkParser(value)}</Text>
     </Stack>
   )
 }

--- a/src/client/components/displays/LineDisplay.tsx
+++ b/src/client/components/displays/LineDisplay.tsx
@@ -44,8 +44,14 @@ export const LineDisplay: FC<LineDisplayProps> = ({ label, value }) => {
       }
 
       outputNode.push(
-        <Link key={keyIndex++} href={getValidLink(linkParams[1])} isExternal>
-          {linkParams[0]} <Icon as={BiLinkExternal} sx={styles.hyperlinkIcon} />
+        <Link
+          key={keyIndex++}
+          href={getValidLink(linkParams[1])}
+          isExternal
+          sx={styles.hyperlink}
+        >
+          {linkParams[0]}
+          <Icon as={BiLinkExternal} sx={styles.hyperlinkIcon} />
         </Link>
       )
     }

--- a/src/client/theme/components/LineDisplay.ts
+++ b/src/client/theme/components/LineDisplay.ts
@@ -1,5 +1,5 @@
 export const LineDisplay = {
-  parts: ['container', 'label', 'value'],
+  parts: ['container', 'label', 'value', 'hyperlinkIcon'],
   baseStyle: {
     container: {
       flexDirection: { base: 'column', md: 'row' },
@@ -17,6 +17,10 @@ export const LineDisplay = {
       fontWeight: 'bold',
       fontSize: '24px',
       lineHeight: '32px',
+    },
+    hyperlinkIcon: {
+      mx: 0,
+      boxSize: 4,
     },
   },
   variants: {

--- a/src/client/theme/components/LineDisplay.ts
+++ b/src/client/theme/components/LineDisplay.ts
@@ -18,8 +18,13 @@ export const LineDisplay = {
       fontSize: '24px',
       lineHeight: '32px',
     },
+    hyperlink: {
+      textDecorationLine: 'underline',
+    },
     hyperlinkIcon: {
       mx: 0,
+      ml: 1,
+      mb: 0.5,
       boxSize: 4,
     },
   },


### PR DESCRIPTION
## Problem

Enable users to input hyperlinks in the form of expression e.g `link('Hello','https://google.com')`

Closes #667

## Solution

Implement in-string hyperlinks (e.g: `"Hello this is a link('link','https://google.com') that will redirect you to Google!"` via a link parser that operates on string results before being displayed.

However, do note that due to the nature of how double quotes `"` are used to denote strings, the text within the link function should either have no quotes (as in `link(link, https://google.com)` or single quotes (as above).

**Features**:

- add link parser to line-display

**Improvements**:

- updated theme styles for link icons

## Screenshots

![Screenshot 2021-06-10 at 1 45 38 PM](https://user-images.githubusercontent.com/21305518/121471504-62b17e00-c9f2-11eb-9ba6-fa5a59bd8a97.png)

## Tests

- [ ] Check normal use case: `"Hello link('Google', 'https://google.com')!"`
- [ ] Check use case without quotes: `"Hello link(Google, https://google.com)!"`
- [ ] Check use case with extra spaces: `"Hello link(    Google , https://google.com      )!"`
- [ ] Check use case with incomplete URL: `"Hello link(Google, google.com)!"`
- [ ] Check that clicking any of the above links directs you to Google on a new tab
