### PR TITLE
feat: add cache headers and hash to filename for static assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
             echo OTP_SECRET=${{ secrets.OTP_SECRET_STAGING }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_STAGING }} >> $GITHUB_ENV;
             echo APP_HOST=staging.checkfirst.gov.sg >> $GITHUB_ENV;
+            echo DEPLOY_TIMESTAMP=$(date) >> $GITHUB_ENV;
           elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
             echo LAMBDA_NODE_ENV=production >> $GITHUB_ENV;
             echo VPC_SUBNET_A=${{ secrets.VPC_SUBNET_A_PRODUCTION }} >> $GITHUB_ENV;
@@ -130,7 +131,8 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_PRODUCTION }} >> $GITHUB_ENV;
-            echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV
+            echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV;
+            echo DEPLOY_TIMESTAMP=$(date) >> $GITHUB_ENV
           fi
       - run: npm run build
         env: 

--- a/serverless.yml
+++ b/serverless.yml
@@ -48,6 +48,7 @@ functions:
       BACKEND_SENTRY_DSN: ${env:BACKEND_SENTRY_DSN}
       CSP_REPORT_URI: ${env:CSP_REPORT_URI}
       APP_HOST: ${env:APP_HOST}
+      DEPLOY_TIMESTAMP: ${env:DEPLOY_TIMESTAMP}
     events:
       - http:
           path: api/v1/{proxy+}
@@ -62,6 +63,7 @@ functions:
     environment:
       FRONTEND_SENTRY_DSN: ${env:FRONTEND_SENTRY_DSN}
       CSP_REPORT_URI: ${env:CSP_REPORT_URI}
+      DEPLOY_TIMESTAMP: ${env:DEPLOY_TIMESTAMP}
     events:
       - http:
           path: ""

--- a/serverless.yml
+++ b/serverless.yml
@@ -81,7 +81,7 @@ functions:
           path: login
           method: get
       - http:
-          path: dashboard
+          path: dashboard/{proxy+}
           method: get
       - http:
           path: builder/{proxy+}

--- a/src/server/bootstrap/cache.ts
+++ b/src/server/bootstrap/cache.ts
@@ -23,3 +23,13 @@ export function noCacheHeaders(
   res.setHeader('Pragma', 'no-cache')
   next()
 }
+
+export function noStoreHeaders(
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  // Do not cache at all and set max-age to expire all existing cached
+  res.setHeader('Cache-Control', 'no-store, max-age=0')
+  next()
+}

--- a/src/server/bootstrap/cache.ts
+++ b/src/server/bootstrap/cache.ts
@@ -1,0 +1,22 @@
+import config from '../config'
+import { Request, Response, NextFunction } from 'express'
+
+export function cacheHeaders(
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const modified = new Date(config.get('deployTimestamp')).toUTCString()
+  res.setHeader('Last-Modified', modified)
+  next()
+}
+
+export function noCacheHeaders(
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  // Prevent caching at all and set max-age to 0 to invalidate existing cache.
+  res.setHeader('Cache-Control', 'no-store, max-age=0')
+  next()
+}

--- a/src/server/bootstrap/cache.ts
+++ b/src/server/bootstrap/cache.ts
@@ -16,7 +16,10 @@ export function noCacheHeaders(
   res: Response,
   next: NextFunction
 ): void {
-  // Prevent caching at all and set max-age to 0 to invalidate existing cache.
-  res.setHeader('Cache-Control', 'no-store, max-age=0')
+  // Use no-cache to force re-validation for every request and support
+  // 304s if etag remains the same.
+  res.setHeader('Cache-Control', 'no-cache')
+  // for HTTP1.0 backward compatibility
+  res.setHeader('Pragma', 'no-cache')
   next()
 }

--- a/src/server/bootstrap/index.ts
+++ b/src/server/bootstrap/index.ts
@@ -34,6 +34,7 @@ import logger from './logger'
 import morgan from './morgan'
 import addStaticRoutes from './static'
 import helmet from './helmet'
+import { noCacheHeaders } from './cache'
 
 const step = config.get('otpExpiry') / 2
 
@@ -154,6 +155,7 @@ export async function bootstrap(): Promise<{
     sessionMiddleware,
     bodyParser.json(),
     sentrySessionMiddleware, // TODO: debug why user info isn't sent
+    noCacheHeaders,
   ]
   app.use('/api/v1', apiMiddleware, api({ checker, auth, template }))
 

--- a/src/server/bootstrap/static.ts
+++ b/src/server/bootstrap/static.ts
@@ -1,15 +1,37 @@
 import path from 'path'
 import express, { Express, Request, Response } from 'express'
-import { cacheHeaders } from '../bootstrap/cache'
+import { cacheHeaders, noStoreHeaders } from '../bootstrap/cache'
 
 export async function addStaticRoutes(app: Express): Promise<Express> {
+  const sendIndex = [
+    // We do not want the browser to cache the pages at all to ensure that we
+    // always load the latest html.
+    noStoreHeaders,
+    (_req: Request, res: Response) => {
+      res.sendFile(
+        path.resolve(__dirname + '/../../../build/client/index.html'),
+        {
+          lastModified: false,
+          etag: false,
+        }
+      )
+    },
+  ]
+
+  // Rather than using a catch all '*', we want to avoid serving index.html for static
+  // assets that do not exists. Instead we want to return 404s to prevent CloudFlare
+  // from caching the results for too long. For e.g., assets/js/missing.js will return
+  // index.html with a catch all.
+  app.get('/', sendIndex)
+  app.get('/login', sendIndex)
+  app.get('/c/:id', sendIndex)
+  app.get('/dashboard/?*', sendIndex)
+  app.get('/builder/?*', sendIndex)
+
+  // Last-Modified headers applies only to static assets like js, images, etc.
   app.use(cacheHeaders)
   app.use(express.static(path.resolve(__dirname + '/../../../build/client')))
   app.use(express.static(path.resolve(__dirname + '/../../../public')))
-
-  app.get('*', (_req: Request, res: Response) => {
-    res.sendFile(path.resolve(__dirname + '/../../../build/client/index.html'))
-  })
 
   return app
 }

--- a/src/server/bootstrap/static.ts
+++ b/src/server/bootstrap/static.ts
@@ -1,11 +1,12 @@
 import path from 'path'
 import express, { Express, Request, Response } from 'express'
+import { cacheHeaders } from '../bootstrap/cache'
 
 export async function addStaticRoutes(app: Express): Promise<Express> {
+  app.use(cacheHeaders)
   app.use(express.static(path.resolve(__dirname + '/../../../build/client')))
   app.use(express.static(path.resolve(__dirname + '/../../../public')))
 
-  // Facilitate deep-linking
   app.get('*', (_req: Request, res: Response) => {
     res.sendFile(path.resolve(__dirname + '/../../../build/client/index.html'))
   })

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -121,6 +121,11 @@ const config = convict({
     format: '*',
     default: '',
   },
+  deployTimestamp: {
+    doc: 'Deployment timestamp used for providing value of Last-Modified header',
+    env: 'DEPLOY_TIMESTAMP',
+    default: new Date().toUTCString(),
+  },
 })
 
 export default config

--- a/src/server/serverless/static.ts
+++ b/src/server/serverless/static.ts
@@ -10,6 +10,7 @@ const BINARY_CONTENT_TYPES = ['image/png']
 const app = express()
 app.use(morgan)
 app.use(helmet)
+
 addStaticRoutes(app)
 
 export const handler: Handler = serverless(app, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = () => {
       assetModuleFilename: 'assets/[name][ext]',
     },
     optimization: {
+      moduleIds: 'deterministic',
       splitChunks: {
         cacheGroups: {
           commons: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = () => {
     },
     output: {
       path: path.join(__dirname, outputDirectory),
-      filename: 'assets/js/[name].bundle.js',
+      filename: 'assets/js/[name].[contenthash].bundle.js',
       publicPath: '/',
       assetModuleFilename: 'assets/[name][ext]',
     },


### PR DESCRIPTION
## Problem
Apart from #644, this PR also addresses a others issues that we were having with our caching configuration previously:
1. CloudFlare was always revalidating static assets instead of caching it as `Cache-Control` was set to `public,max-age=0`.
2. Static assets were not getting revalidated correctly because the `Last-Modified` header was always set to a date in 1980. Express by default uses the last modified date of the file on the filesystem. But in this case, running in lambda result in an unexpected behaviour.
3. Request for non-existent assets were returning `index.html` instead of returning a 404. This results in CloudFlare caching `index.html` as the response for any non-existent routes

Closes #644 

## Solution
- Set last modified date to the deployed timestamp so that requests can be revalidated correctly
- Added a CloudFlare page rule to address (1)
- Only return `index.html` for only defined routes
- Set `no-store` for all pages serving `index.html` to ensure that they are never stored

## Tests
- [ ] First deploy staging branch and load the page. Allow the use of cache by unchecking the `Disable cache` option on the Network tab of Chrome inspector. Deploy this branch and refresh page. You should see that the new js files are requested.
