### PR TITLE
fix: add routing to dashboard base route

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -81,6 +81,9 @@ functions:
           path: login
           method: get
       - http:
+          path: dashboard
+          method: get
+      - http:
           path: dashboard/{proxy+}
           method: get
       - http:


### PR DESCRIPTION
## Problem
Trying to navigate to `/dashboard` directly returns a 403.

## Solution

**Bug Fixes**:
- Add route to `serverless.yml`

## Tests
- [ ] Deploy to staging and navigate to `/dashboard` directly. It should not return a 403.