### PR TITLE
fix(default-tooltip): remove tooltip delay

### DIFF
--- a/src/client/components/common/DefaultTooltip.tsx
+++ b/src/client/components/common/DefaultTooltip.tsx
@@ -12,6 +12,5 @@ export const DefaultTooltip: FC<TooltipProps> = ({ ...props }) => (
 
 DefaultTooltip.defaultProps = {
   gutter: 16,
-  openDelay: 800,
   hasArrow: true,
 }


### PR DESCRIPTION
## Problem

Currently, the tooltip delay has a tendency to create visual glitches, which is turning out to affect the UI more than it actually helps it. As such, the designer has indicated that we should remove the tooltip delay to keep the UI smooth and glitch-free rather than deal with the intermittent glitches.

## Solution

**Bug Fixes**:

- Remove the 800ms open delay from `DefaultTooltip`

## Tests

- [x] Tooltips should now open instantly on hover 
