### PR TITLE
fix(styled-toast): fix text overflow behaviour using styles

### DIFF
--- a/src/client/theme/components/StyledToast.tsx
+++ b/src/client/theme/components/StyledToast.tsx
@@ -30,7 +30,7 @@ export const StyledToast: ComponentMultiStyleConfig = {
       pointerEvents: 'auto',
     },
     container: {
-      alignItems: 'stretch',
+      alignItems: 'start',
     },
     icon: {
       boxSize: '24px',
@@ -38,6 +38,10 @@ export const StyledToast: ComponentMultiStyleConfig = {
     },
     message: {
       textStyle: 'body1',
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: { md: 'nowrap' },
+      maxHeight: 12,
     },
     closeButton: {
       minW: '24px',


### PR DESCRIPTION
## Problem

Currently, styled toasts don't handle messages longer than itself properly. To align with the design system, toasts should be a maximum of one line long on desktop screens and two lines long on mobile screens.

Partially solves #393

## Solution

**Bug Fixes**:

- Update message styles to implement text cutoff after the maximum length is reached

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-06-17 at 5 16 51 PM](https://user-images.githubusercontent.com/21305518/122370463-a88db980-cf91-11eb-9b1e-abca9a5df512.png)

**AFTER**:
![Screenshot 2021-06-17 at 5 17 32 PM](https://user-images.githubusercontent.com/21305518/122370489-ad526d80-cf91-11eb-827f-dd20980fb889.png)

## Tests

- [ ] Create a checker with a long title. Ensure that the toast does not exceed one line on desktop, or two lines on mobile.
