### PR TITLE
chore: ignore dependabot commits from CHANGELOG

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,0 +1,4 @@
+{
+	"package": true,
+	"ignoreCommitPattern": "^chore(\\(deps(-dev)?\\))?: bump.*"
+}

--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,4 +1,4 @@
 {
 	"package": true,
-	"ignoreCommitPattern": "^chore(\\(deps(-dev)?\\))?: bump.*"
+	"ignoreCommitPattern": "^((chore)|(fix))(\\(deps(-dev)?\\))?: bump.*"
 }


### PR DESCRIPTION
## Problem

A lot of dependabot commits were clogging up the CHANGELOG. Important commits by humans were not visible under loads of commits from the bot.

Closes #550.

## Solution

I added a config file to ignore commits that look like: `chore(\(deps(-dev)?\))?: bump.*`

**Improvements**:

- No more weird commits in the CHANGELOG!

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-07-08 at 9 36 56 AM](https://user-images.githubusercontent.com/932949/124848784-1a28b880-dfd0-11eb-8ff3-f1d0711fcaea.png)

**AFTER**:
![Screenshot 2021-07-08 at 9 37 15 AM](https://user-images.githubusercontent.com/932949/124848776-16953180-dfd0-11eb-821e-1efca48bf966.png)

## Tests

Run `npm run version` and observe.