### PR TITLE
fix(frontend): spacing and alignment for radio and checkbox options

### DIFF
--- a/src/client/components/builder/questions/CheckboxField.tsx
+++ b/src/client/components/builder/questions/CheckboxField.tsx
@@ -171,7 +171,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
         )}
       </VStack>
       <CheckboxGroup>
-        <VStack sx={styles.previewOptionsContainer} spacing={0}>
+        <VStack sx={styles.previewOptionsContainer} spacing="24px">
           {options.map(({ value, label }, i) => (
             <Flex key={i} sx={styles.previewOptionRowContainer}>
               <Checkbox

--- a/src/client/components/builder/questions/CheckboxField.tsx
+++ b/src/client/components/builder/questions/CheckboxField.tsx
@@ -23,6 +23,7 @@ import { useCheckerContext } from '../../../contexts'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 
 import '../../../styles/big-checkbox.css'
+import '../../../styles/builder-field.css'
 import { TitlePreviewText } from './TitlePreviewText'
 
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
@@ -173,7 +174,11 @@ const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
       <CheckboxGroup>
         <VStack sx={styles.previewOptionsContainer} spacing="24px">
           {options.map(({ value, label }, i) => (
-            <Flex key={i} sx={styles.previewOptionRowContainer}>
+            <Flex
+              key={i}
+              sx={styles.previewOptionRowContainer}
+              className="builder-field"
+            >
               <Checkbox
                 sx={styles.checkbox}
                 className="big-checkbox"

--- a/src/client/components/builder/questions/RadioField.tsx
+++ b/src/client/components/builder/questions/RadioField.tsx
@@ -165,7 +165,7 @@ const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
         )}
       </VStack>
       <RadioGroup>
-        <VStack sx={styles.previewOptionsContainer} spacing={0}>
+        <VStack sx={styles.previewOptionsContainer} spacing="24px">
           {options.map(({ value, label }, i) => (
             <Flex key={i} sx={styles.previewOptionRowContainer}>
               <Radio

--- a/src/client/components/builder/questions/RadioField.tsx
+++ b/src/client/components/builder/questions/RadioField.tsx
@@ -23,6 +23,8 @@ import { createBuilderField, QuestionFieldComponent } from '../BuilderField'
 import { BuilderActionEnum, ConfigArrayEnum } from '../../../../util/enums'
 import { TitlePreviewText } from './TitlePreviewText'
 
+import '../../../styles/builder-field.css'
+
 const InputComponent: QuestionFieldComponent = ({ field, index }) => {
   const { title, description } = field
   const { dispatch } = useCheckerContext()
@@ -167,7 +169,11 @@ const PreviewComponent: QuestionFieldComponent = ({ field, index }) => {
       <RadioGroup>
         <VStack sx={styles.previewOptionsContainer} spacing="24px">
           {options.map(({ value, label }, i) => (
-            <Flex key={i} sx={styles.previewOptionRowContainer}>
+            <Flex
+              key={i}
+              sx={styles.previewOptionRowContainer}
+              className="builder-field"
+            >
               <Radio
                 sx={styles.radio}
                 spacing={4}

--- a/src/client/styles/builder-field.css
+++ b/src/client/styles/builder-field.css
@@ -1,0 +1,9 @@
+.builder-field .chakra-checkbox,
+.builder-field .chakra-radio {
+  align-items: flex-start;
+}
+
+.builder-field .chakra-checkbox__control,
+.builder-field .chakra-radio__control {
+  margin-top: 8px;
+}

--- a/src/client/styles/checker-field.css
+++ b/src/client/styles/checker-field.css
@@ -1,18 +1,29 @@
-/*  
-  Scroll-margin-top styling for checkbox and radio inputs.
+.checker-field .chakra-checkbox__input,
+.checker-field .chakra-radio__input {
+  /*
+    Scroll-margin-top styling for checkbox and radio inputs.
 
-  This style cannot be passed directly to CheckboxInput / RadioInput due to how Chakra composes
-  custom checkboxes.
+    This style cannot be passed directly to CheckboxInput / RadioInput due to how Chakra composes
+    custom checkboxes.
 
-  In this case, Chakra uses a hidden native checkbox/radio input in conjunction with a styled
-  control element. Styles props passed to CheckboxInput / RadioInput are passed down to
-  the control element instead, which would work for 99% of use cases.
-  
-  However, the ref element returned by CheckboxInput / RadioInput, which we pass to react-hook-form
-  for handling scroll-into-view, refers to the hidden native input element instead. As this element
-  does not recieve the styles from the style prop passed to CheckboxInput / RadioInput, we thus
-  resort to using CSS class style overrides to implement scroll margins instead.
-*/
-.checker-field .chakra-checkbox__input, .checker-field .chakra-radio__input {
+    In this case, Chakra uses a hidden native checkbox/radio input in conjunction with a styled
+    control element. Styles props passed to CheckboxInput / RadioInput are passed down to
+    the control element instead, which would work for 99% of use cases.
+
+    However, the ref element returned by CheckboxInput / RadioInput, which we pass to react-hook-form
+    for handling scroll-into-view, refers to the hidden native input element instead. As this element
+    does not recieve the styles from the style prop passed to CheckboxInput / RadioInput, we thus
+    resort to using CSS class style overrides to implement scroll margins instead.
+  */
   scroll-margin-top: 88px;
+}
+
+.checker-field .chakra-checkbox,
+.checker-field .chakra-radio {
+  align-items: flex-start;
+}
+
+.checker-field .chakra-checkbox__control,
+.checker-field .chakra-radio__control {
+  margin-top: 8px;
 }

--- a/src/client/theme/components/builder/questions/CheckboxField.tsx
+++ b/src/client/theme/components/builder/questions/CheckboxField.tsx
@@ -33,9 +33,7 @@ export const CheckboxField: ComponentMultiStyleConfig = {
       alignItems: 'start',
     },
     previewOptionRowContainer: {
-      h: '40px',
       px: 2,
-      alignItems: 'center',
     },
     checkbox: {
       borderColor: 'secondary.500',

--- a/src/client/theme/components/builder/questions/RadioField.tsx
+++ b/src/client/theme/components/builder/questions/RadioField.tsx
@@ -33,9 +33,7 @@ export const RadioField: ComponentMultiStyleConfig = {
       alignItems: 'start',
     },
     previewOptionRowContainer: {
-      h: '40px',
       px: 2,
-      alignItems: 'center',
     },
     radio: {
       h: 6,


### PR DESCRIPTION
## Problem

Closes #765 

## Solution

**Improvements**:

- Introduce CSS overrides to align radio and checkbox to first line of text

**Bug Fixes**:

- Remove hard-coded height for radio and checkbox options 

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/125271570-7fb4d600-e33d-11eb-8ae2-537a7991ac58.png)

![image](https://user-images.githubusercontent.com/3666479/125271610-88a5a780-e33d-11eb-8023-7ee96b88452f.png)
