### PR TITLE
feat(backend): support whitelisting of non gov.sg domains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_STAGING }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_STAGING }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_STAGING }} >> $GITHUB_ENV;
-            echo MAIL_SUFFIX=${{ secrets.MAIL_SUFFIX_STAGING }} >> $GITHUB_ENV;
+            echo "MAIL_SUFFIX=${{ secrets.MAIL_SUFFIX_STAGING }}" >> $GITHUB_ENV;
             echo APP_HOST=staging.checkfirst.gov.sg >> $GITHUB_ENV;
             echo DEPLOY_TIMESTAMP=$(date) >> $GITHUB_ENV;
           elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
@@ -132,7 +132,7 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_PRODUCTION }} >> $GITHUB_ENV;
-            echo MAIL_SUFFIX=${{ secrets.MAIL_SUFFIX_PRODUCTION }} >> $GITHUB_ENV;
+            echo "MAIL_SUFFIX=${{ secrets.MAIL_SUFFIX_PRODUCTION }}" >> $GITHUB_ENV;
             echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV;
             echo DEPLOY_TIMESTAMP=$(date) >> $GITHUB_ENV
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_STAGING }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_STAGING }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_STAGING }} >> $GITHUB_ENV;
+            echo MAIL_SUFFIX=${{ secrets.MAIL_SUFFIX_STAGING }} >> $GITHUB_ENV;
             echo APP_HOST=staging.checkfirst.gov.sg >> $GITHUB_ENV;
             echo DEPLOY_TIMESTAMP=$(date) >> $GITHUB_ENV;
           elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
@@ -131,6 +132,7 @@ jobs:
             echo SESSION_SECRET=${{ secrets.SESSION_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo OTP_SECRET=${{ secrets.OTP_SECRET_PRODUCTION }} >> $GITHUB_ENV;
             echo GA_TRACKING_ID=${{ secrets.GA_TRACKING_ID_PRODUCTION }} >> $GITHUB_ENV;
+            echo MAIL_SUFFIX=${{ secrets.MAIL_SUFFIX_PRODUCTION }} >> $GITHUB_ENV;
             echo APP_HOST=checkfirst.gov.sg >> $GITHUB_ENV;
             echo DEPLOY_TIMESTAMP=$(date) >> $GITHUB_ENV
           fi

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,6 +49,7 @@ functions:
       CSP_REPORT_URI: ${env:CSP_REPORT_URI}
       APP_HOST: ${env:APP_HOST}
       DEPLOY_TIMESTAMP: ${env:DEPLOY_TIMESTAMP}
+      MAIL_SUFFIX: ${env:MAIL_SUFFIX}
     events:
       - http:
           path: api/v1/{proxy+}

--- a/src/server/bootstrap/index.ts
+++ b/src/server/bootstrap/index.ts
@@ -43,7 +43,6 @@ const totp = totpFactory.clone({ step, window: [1, 0] })
 const mailSuffix = config.get('mailSuffix')
 
 const emailValidator = new minimatch.Minimatch(mailSuffix, {
-  noext: true,
   noglobstar: true,
   nobrace: true,
   nonegate: true,

--- a/src/server/database/models/User.ts
+++ b/src/server/database/models/User.ts
@@ -15,7 +15,6 @@ import { UserToChecker } from './UserToChecker'
 
 const mailSuffix = config.get('mailSuffix')
 const emailValidator = new minimatch.Minimatch(mailSuffix, {
-  noext: true,
   noglobstar: true,
   nobrace: true,
   nonegate: true,


### PR DESCRIPTION
## Problem

Closes #829 

## Solution

**Features**:
- Allow the use of `extglob` to specify multiple white listed domain. E.g. `@(*.gov.sg|*@example.com)`

## Tests
- Ensure that unit tests passes
- Whitelist a non .gov.sg domain. You should be able to login with an email from that domain. You can use the test email address in our 1Password labeled "Verified non gov.sg email".
- You should not be able to login with an email not from the list of whitelisted domains.