### PR TITLE
fix(frontend): always use fixed notation for numbers

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -1,3 +1,4 @@
+import * as mathjs from 'mathjs'
 import React, { FC, useState, useRef } from 'react'
 import { BiEditAlt } from 'react-icons/bi'
 import { VscDebugRestart } from 'react-icons/vsc'
@@ -43,6 +44,10 @@ function isUnit(
   return (output as Unit).toNumber !== undefined
 }
 
+function isNumeric(output: unknown): output is number {
+  return !isNaN(parseFloat(output as string)) && isFinite(output as number)
+}
+
 export const Checker: FC<CheckerProps> = ({ config }) => {
   const styledToast = useStyledToast()
   const styles = useMultiStyleConfig('Checker', {})
@@ -70,25 +75,25 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
 
   const renderDisplay = (operation: checker.Operation, i: number) => {
     const output = variables[operation.id]
+    let value: string
+    if (isUnit(output)) {
+      value = new Date(output.toNumber('seconds') * 1000).toLocaleString(
+        'default',
+        {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        }
+      )
+    } else if (isNumeric(output)) {
+      value = mathjs.format(output, { notation: 'fixed' })
+    } else {
+      value = output.toString()
+    }
 
     return (
       operation.show && (
-        <LineDisplay
-          key={i}
-          label={operation.title}
-          value={
-            isUnit(output)
-              ? new Date(output.toNumber('seconds') * 1000).toLocaleString(
-                  'default',
-                  {
-                    day: 'numeric',
-                    month: 'long',
-                    year: 'numeric',
-                  }
-                )
-              : (output as string)
-          }
-        />
+        <LineDisplay key={i} label={operation.title} value={value} />
       )
     )
   }

--- a/src/client/core/parser.ts
+++ b/src/client/core/parser.ts
@@ -30,7 +30,16 @@ export const parseConditionalExpr = (expression: string): IfelseState => {
   */
   const dfs = (node: mathjs.MathNode, conds: string[], ops: string[]) => {
     const { op, args } = node
-    if (op !== 'and' && op !== 'or') return conds.push(node.toString())
+    if (op !== 'and' && op !== 'or')
+      return conds.push(
+        node.toString({
+          handler: (node: mathjs.MathNode) => {
+            // Override toString for ConstantNode to always use fixed notation
+            if (node.type === 'ConstantNode')
+              return mathjs.format(node.value, { notation: 'fixed' })
+          },
+        })
+      )
     if (!args || args.length !== 2) return
 
     const [left, right] = args


### PR DESCRIPTION
## Problem

Closes #668 

## Solution

**Improvements**:
- Pass a handler to `ConditionalResult` to ensure that `ConstantNode.toString` uses fixed notation
- Format numeric result explicitly with fixed notation

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/127309010-29b7cb22-6f39-43c7-9107-6827d1f056ec.png)

![image](https://user-images.githubusercontent.com/3666479/127309051-a1317ead-4e7a-43c0-a8ac-9e817f3814e0.png)

## Tests
- [ ] Create a new conditional result with a large numeric value used in the condition (e.g. `1 > 61234567890`). The value should not be expressed in exponential notation when clicking away and then back to the block.
- [ ] Create an operation that will display a result with a large number (e.g. `1 + 1000000000000`). Submit the checker and observe that the result is in fixed notation.