### PR TITLE
fix(frontend): padding for checker

### DIFF
--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -5,7 +5,6 @@ import { isEmpty, filter } from 'lodash'
 import {
   useMultiStyleConfig,
   StylesProvider,
-  Container,
   VStack,
   Stack,
   Flex,
@@ -196,7 +195,12 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
 
   return (
     <StylesProvider value={styles}>
-      <Container maxW="xl" p={8} mb={4} sx={{ overscrollBehavior: 'contain' }}>
+      <Flex
+        w={{ base: '100%', lg: '832px' }}
+        p="40px"
+        bg="white"
+        sx={{ overscrollBehavior: 'contain' }}
+      >
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <VStack align="stretch" spacing={10}>
@@ -218,40 +222,48 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
             </VStack>
           </form>
         </FormProvider>
-      </Container>
+      </Flex>
 
       {!isEmpty(variables) && isCheckerComplete() && (
-        <Flex bg="primary.500" as="div" ref={outcomes} flex={1}>
-          <Container maxW="xl" pt={8} pb={16} px={8} color="neutral.200">
-            <VStack align="stretch" spacing="40px">
-              {operations.map(renderDisplay)}
-              <Stack
-                direction={{ base: 'column', md: 'row' }}
-                alignItems="center"
-                justifyContent="center"
-                spacing="16px"
+        <Flex
+          w={{ base: '100%', md: '832px' }}
+          bg="primary.500"
+          as="div"
+          ref={outcomes}
+          flex={1}
+          color="neutral.200"
+          pt={8}
+          pb={16}
+          px={8}
+        >
+          <VStack align="stretch" spacing="40px">
+            {operations.map(renderDisplay)}
+            <Stack
+              direction={{ base: 'column', md: 'row' }}
+              alignItems="center"
+              justifyContent="center"
+              spacing="16px"
+            >
+              <Button
+                w={{ base: '100%', md: 'auto' }}
+                _hover={{ bg: 'primary.300' }}
+                rightIcon={<BiEditAlt />}
+                variant="outline"
+                onClick={() => reset(true)}
               >
-                <Button
-                  w={{ base: '100%', md: 'auto' }}
-                  _hover={{ bg: 'primary.300' }}
-                  rightIcon={<BiEditAlt />}
-                  variant="outline"
-                  onClick={() => reset(true)}
-                >
-                  Edit fields
-                </Button>
-                <Button
-                  w={{ base: '100%', md: 'auto' }}
-                  _hover={{ bg: 'primary.300' }}
-                  rightIcon={<VscDebugRestart />}
-                  variant="outline"
-                  onClick={() => reset()}
-                >
-                  Restart checker
-                </Button>
-              </Stack>
-            </VStack>
-          </Container>
+                Edit fields
+              </Button>
+              <Button
+                w={{ base: '100%', md: 'auto' }}
+                _hover={{ bg: 'primary.300' }}
+                rightIcon={<VscDebugRestart />}
+                variant="outline"
+                onClick={() => reset()}
+              >
+                Restart checker
+              </Button>
+            </Stack>
+          </VStack>
         </Flex>
       )}
     </StylesProvider>

--- a/src/client/components/Checker.tsx
+++ b/src/client/components/Checker.tsx
@@ -202,7 +202,10 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
         sx={{ overscrollBehavior: 'contain' }}
       >
         <FormProvider {...methods}>
-          <form onSubmit={methods.handleSubmit(onSubmit)}>
+          <form
+            style={{ width: '100%' }}
+            onSubmit={methods.handleSubmit(onSubmit)}
+          >
             <VStack align="stretch" spacing={10}>
               <VStack spacing={2}>
                 <Text ref={header} sx={styles.title}>
@@ -226,17 +229,17 @@ export const Checker: FC<CheckerProps> = ({ config }) => {
 
       {!isEmpty(variables) && isCheckerComplete() && (
         <Flex
-          w={{ base: '100%', md: '832px' }}
+          w={{ base: '100%', lg: '832px' }}
           bg="primary.500"
           as="div"
           ref={outcomes}
-          flex={1}
+          flex={{ base: 1, lg: '0' }}
           color="neutral.200"
           pt={8}
           pb={16}
           px={8}
         >
-          <VStack align="stretch" spacing="40px">
+          <VStack w="100%" align="stretch" spacing="40px">
             {operations.map(renderDisplay)}
             <Stack
               direction={{ base: 'column', md: 'row' }}

--- a/src/client/components/builder/PreviewTab.tsx
+++ b/src/client/components/builder/PreviewTab.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Container } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 
 import { useCheckerContext } from '../../contexts'
 import { Checker } from '../../components'
@@ -8,16 +8,8 @@ export const PreviewTab: FC = () => {
   const { config } = useCheckerContext()
 
   return (
-    <Container
-      mt="64px"
-      mb="64px"
-      maxW="xl"
-      pt="32px"
-      px="0px"
-      bg="white"
-      borderRadius="12px"
-    >
+    <Box my="64px">
       <Checker config={config} />
-    </Container>
+    </Box>
   )
 }

--- a/src/client/components/dashboard/CheckerCard.tsx
+++ b/src/client/components/dashboard/CheckerCard.tsx
@@ -175,8 +175,8 @@ export const CheckerCard: FC<CheckerCardProps> = ({ checker }) => {
     <>
       <Link to={{ pathname: `/builder/${checker.id}` }}>
         <VStack sx={styles.card} align="stretch" role="group">
-          <VStack align="stretch" spacing="8px">
-            <Text flex={1} sx={styles.title} noOfLines={3}>
+          <VStack align="stretch" spacing="8px" flex={1}>
+            <Text sx={styles.title} noOfLines={3}>
               {checker.title}
             </Text>
             <Text flex={1} sx={styles.subtitle} isTruncated>

--- a/src/client/components/dashboard/PreviewTemplate.tsx
+++ b/src/client/components/dashboard/PreviewTemplate.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Button,
   HStack,
-  Container,
+  Center,
   Text,
   Link,
   useMultiStyleConfig,
@@ -60,9 +60,9 @@ export const PreviewTemplate: FC = () => {
           </HStack>
         }
       />
-      <Container sx={styles.checkerContainer}>
+      <Center sx={styles.checkerContainer} direction="column">
         {!isLoading ? <Checker config={config} /> : null}
-      </Container>
+      </Center>
     </Flex>
   )
 }

--- a/src/client/components/dashboard/PreviewTemplate.tsx
+++ b/src/client/components/dashboard/PreviewTemplate.tsx
@@ -7,7 +7,6 @@ import {
   IconButton,
   Button,
   HStack,
-  Center,
   Text,
   Link,
   useMultiStyleConfig,
@@ -60,9 +59,9 @@ export const PreviewTemplate: FC = () => {
           </HStack>
         }
       />
-      <Center sx={styles.checkerContainer} direction="column">
+      <Flex sx={styles.checkerContainer} direction="column" alignItems="center">
         {!isLoading ? <Checker config={config} /> : null}
-      </Center>
+      </Flex>
     </Flex>
   )
 }

--- a/src/client/pages/Checker.tsx
+++ b/src/client/pages/Checker.tsx
@@ -27,7 +27,13 @@ export const Checker: FC = () => {
   } = useQuery(['checker', id], () => CheckerService.getPublishedChecker(id))
 
   return (
-    <Flex direction="column" bg="neutral.200" minH="100vh">
+    <Flex
+      direction="column"
+      bg={{ base: 'white', lg: 'neutral.200' }}
+      alignItems="center"
+      minH="100vh"
+      py={{ base: '0px', lg: '64px' }}
+    >
       {!isLoading && !isError && config && config.isActive && (
         <CheckerComponent config={config} />
       )}

--- a/src/client/pages/FormBuilder.tsx
+++ b/src/client/pages/FormBuilder.tsx
@@ -43,17 +43,16 @@ const WithNavBar: FC = ({ children }) => {
 const WithPreviewNavBar: FC = ({ children }) => (
   <Flex direction="column" minH="100vh" bgColor="neutral.200">
     <PreviewNavBar />
-    <Container
+    <Flex
       h="calc(100vh - 73px)"
       overflow="auto"
       mt="73px"
-      maxW="100vw"
       pb="32px"
+      direction="column"
+      alignItems="center"
     >
-      <Container maxW="756px" px={0}>
-        {children}
-      </Container>
-    </Container>
+      {children}
+    </Flex>
   </Flex>
 )
 

--- a/src/client/theme/components/PreviewTemplate.tsx
+++ b/src/client/theme/components/PreviewTemplate.tsx
@@ -21,13 +21,12 @@ export const PreviewTemplate: ComponentMultiStyleConfig = {
       minW: 6,
     },
     checkerContainer: {
-      mt: '144px',
+      mt: '72px',
       mb: '64px',
-      maxW: 'xl',
       pt: '32px',
       px: '0px',
-      bg: 'white',
-      borderRadius: '12px',
+      w: '100%',
+      flexDir: 'column',
     },
   },
 }


### PR DESCRIPTION
## Problem

Closes #820 

## Solution

**Bug Fixes**:
- Updated styles and padding for the following:
   - Checker for preview page
   - Checker page
   - Embedded checker
   - Template preview

## Before & After Screenshots

![image](https://user-images.githubusercontent.com/3666479/127968437-c1eb815e-03a8-4f99-a4a7-99d180cc8547.png)

![image](https://user-images.githubusercontent.com/3666479/127968470-3748b36d-2858-4ea7-adf1-fbb67e0d5053.png)

## Tests
- [ ] Verify that public checker page works as expected for both mobile and desktop
- [ ] Verify that embedded checker works
- [ ] Verify that preview template checker works as expected
- [ ] Verify that preview checker works as expected