### PR TITLE
feat(frontend): help button enhancements

### DIFF
--- a/src/client/components/builder/HelpButton.tsx
+++ b/src/client/components/builder/HelpButton.tsx
@@ -24,20 +24,11 @@ import { Text } from '@chakra-ui/layout'
 import {
   BiArrowBack,
   BiCalculator,
-  BiCalendar,
-  BiGitBranch,
-  BiGitCompare,
   BiQuestionMark,
-  BiRadioCircleMarked,
   BiTable,
+  BiText,
 } from 'react-icons/bi'
-import {
-  FiAtSign,
-  HiHashtag,
-  IoEyeOutline,
-  RiArrowRightSLine,
-  RiCheckboxMultipleBlankFill,
-} from 'react-icons/all'
+import { FiAtSign, IoEyeOutline, RiArrowRightSLine } from 'react-icons/all'
 import { useGoogleAnalytics } from '../../contexts'
 import { DefaultTooltip } from '../common/DefaultTooltip'
 import { useRouteMatch } from 'react-router-dom'
@@ -82,65 +73,40 @@ export const HelpButton: FC = () => {
 
   const questionTabs: HelpLink[] = [
     {
-      title: 'Numeric',
-      link: 'https://guide.checkfirst.gov.sg/features/form-builder#question-types',
-      icon: HiHashtag,
-    },
-    {
-      title: 'Radio question',
-      link: 'https://guide.checkfirst.gov.sg/features/form-builder#question-types',
-      icon: BiRadioCircleMarked,
-    },
-    {
-      title: 'Checkbox question',
-      link: 'https://guide.checkfirst.gov.sg/features/form-builder#question-types',
-      icon: RiCheckboxMultipleBlankFill,
-    },
-    {
-      title: 'Date question',
-      link: 'https://guide.checkfirst.gov.sg/features/form-builder#question-types',
-      icon: BiCalendar,
+      title: 'Learn about Question blocks',
+      link: 'https://go.gov.sg/checkfirst-formbuilder',
+      icon: BiQuestionMark,
     },
   ]
 
   const constantTableTabs: HelpLink[] = [
     {
-      title: 'Constant tables',
-      link: 'https://guide.checkfirst.gov.sg/features/constants',
+      title: 'Learn about Constant tables',
+      link: 'https://go.gov.sg/checkfirst-constants',
       icon: BiTable,
     },
   ]
 
   const logicTabs: HelpLink[] = [
     {
-      title: 'Referencing questions',
-      link: 'https://guide.checkfirst.gov.sg/features/logic#referencing-blocks',
+      title: 'Learn about Logic blocks',
+      link: 'https://go.gov.sg/checkfirst-logic',
+      icon: BiCalculator,
+    },
+    {
+      title: 'Referencing Question blocks',
+      link: 'https://go.gov.sg/checkfirst-reference-blocks',
       icon: FiAtSign,
     },
     {
       title: 'Hide/show results',
-      link: 'https://guide.checkfirst.gov.sg/features/logic#how-to-use-logic',
+      link: 'https://go.gov.sg/checkfirst-hide-show-results',
       icon: IoEyeOutline,
     },
     {
-      title: 'Calculated logic',
-      link: 'https://guide.checkfirst.gov.sg/features/logic/calculator-logic',
-      icon: BiCalculator,
-    },
-    {
-      title: 'Conditional logic',
-      link: 'https://guide.checkfirst.gov.sg/features/logic/conditional-logic',
-      icon: BiGitBranch,
-    },
-    {
-      title: 'Date logic',
-      link: 'https://guide.checkfirst.gov.sg/features/logic/date-logic',
-      icon: BiCalendar,
-    },
-    {
-      title: 'Map constant table',
-      link: 'https://guide.checkfirst.gov.sg/features/logic/map-constant',
-      icon: BiGitCompare,
+      title: 'Results formatting',
+      link: 'https://go.gov.sg/checkfirst-format-results',
+      icon: BiText,
     },
   ]
 
@@ -203,6 +169,20 @@ export const HelpButton: FC = () => {
         {overviewListItem('QUESTIONS TAB', PopoverTabState.Questions)}
         {overviewListItem('CONSTANTS TAB', PopoverTabState.Constants)}
         {overviewListItem('LOGIC TAB', PopoverTabState.Logic)}
+        <ListItem display="flex">
+          <OutboundLink
+            eventLabel={GA_USER_EVENTS.BUILDER_HELP_BUTTON}
+            to="https://go.gov.sg/checkfirst-tutorials"
+            target="_blank"
+          >
+            <Button color="primary.500" variant="link" px="10px">
+              <Text fontSize="14px" fontWeight={600}>
+                TUTORIALS
+              </Text>
+            </Button>
+            <Spacer />
+          </OutboundLink>
+        </ListItem>
       </List>
     )
   }

--- a/src/client/components/builder/HelpButton.tsx
+++ b/src/client/components/builder/HelpButton.tsx
@@ -31,7 +31,7 @@ import {
 import { FiAtSign, IoEyeOutline, RiArrowRightSLine } from 'react-icons/all'
 import { useGoogleAnalytics } from '../../contexts'
 import { DefaultTooltip } from '../common/DefaultTooltip'
-import { useRouteMatch } from 'react-router-dom'
+import { useRouteMatch, useHistory, useLocation } from 'react-router-dom'
 
 import { IconType } from 'react-icons'
 
@@ -52,8 +52,12 @@ type HelpLink = {
 
 export const HelpButton: FC = () => {
   const { GA_USER_EVENTS } = useGoogleAnalytics()
+  const history = useHistory()
   const { url } = useRouteMatch()
-  const { onOpen, onClose, isOpen } = useDisclosure()
+  const { state, pathname } = useLocation<{ isNewChecker: boolean }>()
+  const { onOpen, onClose, isOpen } = useDisclosure({
+    defaultIsOpen: state?.isNewChecker,
+  })
   const popoverRef = useRef<HTMLDivElement>(null)
 
   const [currentTabState, setTabState] = useState(PopoverTabState.Overall)
@@ -68,7 +72,11 @@ export const HelpButton: FC = () => {
   // Force-close popover when clicking anywhere outside popover element
   useOutsideClick({
     ref: popoverRef,
-    handler: onClose,
+    handler: () => {
+      // Reset isNewChecker flag if it is set
+      if (state?.isNewChecker) history.replace(pathname, {})
+      onClose()
+    },
   })
 
   const questionTabs: HelpLink[] = [

--- a/src/client/components/dashboard/CreateNewModal.tsx
+++ b/src/client/components/dashboard/CreateNewModal.tsx
@@ -109,7 +109,7 @@ export const CreateNewModal: FC<CreateNewModalProps> = ({ onClose }) => {
         status: 'success',
         description: `${created?.title} has been created successfully`,
       })
-      history.push(`/builder/${created.id}`)
+      history.push(`/builder/${created.id}`, { isNewChecker: true })
     },
     onError: (err) => {
       styledToast({

--- a/src/client/pages/FormBuilder.tsx
+++ b/src/client/pages/FormBuilder.tsx
@@ -2,7 +2,13 @@ import React, { FC } from 'react'
 import { AxiosError } from 'axios'
 import { useIsFetching, useQueryClient } from 'react-query'
 import { Container, Flex } from '@chakra-ui/react'
-import { Switch, Route, Redirect, useRouteMatch } from 'react-router-dom'
+import {
+  Switch,
+  Route,
+  Redirect,
+  useRouteMatch,
+  useLocation,
+} from 'react-router-dom'
 
 import * as checker from '../../types/checker'
 import {
@@ -62,6 +68,7 @@ export const FormBuilder: FC = () => {
     path,
     params: { id },
   } = useRouteMatch<{ id: string }>()
+  const location = useLocation()
   const isLoading = useIsFetching(['builder', id])
   const queryClient = useQueryClient()
   const queryState = queryClient.getQueryState<
@@ -97,7 +104,7 @@ export const FormBuilder: FC = () => {
           <PreviewTab />
         </WithPreviewNavBar>
       </Route>
-      <Redirect to={`${path}/questions`} />
+      <Redirect to={{ pathname: `${path}/questions`, state: location.state }} />
     </Switch>
   )
 }


### PR DESCRIPTION
## Problem

Closes #880 

## Solution

**Improvements**:
- Condensed each help menu section and use go.gov.sg links
- Added "Tutorial" link on main page
- Open help button for newly created checker

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/127998835-62169d10-3220-44de-a3fb-6503bd4bff79.png)

## Tests
- [ ] Create a new checker from scratch. Help button should be opened initially. After clicking outside of the help menu. The menu should be dismissed
- [ ] Create a new checker from template. Help button should be opened initially.