### PR TITLE
feat(frontend): paragraph function

### DIFF
--- a/src/client/components/builder/logic/CalculatorBar.tsx
+++ b/src/client/components/builder/logic/CalculatorBar.tsx
@@ -1,5 +1,40 @@
-import { Box, Flex, FlexProps, Text } from '@chakra-ui/layout'
-import React, { FC, useState } from 'react'
+import { Box, Flex, FlexProps, Text, Icon, Divider } from '@chakra-ui/react'
+import { IconType } from 'react-icons'
+import { BiLink, BiParagraph } from 'react-icons/bi'
+import { ImQuotesLeft } from 'react-icons/im'
+import React, { FC } from 'react'
+
+const OPERATOR_MAP: Array<{ icon: string; value: string }> = [
+  { icon: '@', value: '@' },
+  { icon: '+', value: '+' },
+  { icon: '×', value: '*' },
+  { icon: '÷', value: '/' },
+  { icon: '(', value: '(' },
+  { icon: ')', value: ')' },
+  { icon: '^', value: '^' },
+  { icon: '%', value: '%' },
+  { icon: '>', value: '>' },
+  { icon: '≥', value: '>=' },
+  { icon: '<', value: '<' },
+  { icon: '≤', value: '<=' },
+  { icon: '=', value: '==' },
+  { icon: '≠', value: '!=' },
+]
+
+const FUNCTION_MAP: Array<{ icon: IconType; value: string }> = [
+  {
+    icon: ImQuotesLeft,
+    value: '"Type in text for results"',
+  },
+  {
+    icon: BiParagraph,
+    value: 'paragraph("Type content")',
+  },
+  {
+    icon: BiLink,
+    value: 'link("Type link display name", "https://example.com")',
+  },
+]
 
 interface CalculatorBarProps extends Omit<FlexProps, 'onClick'> {
   onClick: (character: string) => void
@@ -9,54 +44,48 @@ export const CalculatorBar: FC<CalculatorBarProps> = ({
   onClick,
   ...props
 }) => {
-  // use react useState hook to initialise the map only once upon initial render
-  const [operatorMap] = useState(() => {
-    const opMap = new Map<string, string>()
-    opMap.set('@', '@')
-    opMap.set('+', '+')
-    opMap.set('×', '*')
-    opMap.set('÷', '/')
-    opMap.set('(', '(')
-    opMap.set(')', ')')
-    opMap.set('^', '^')
-    opMap.set('%', '%')
-    opMap.set('>', '>')
-    opMap.set('≥', '>=')
-    opMap.set('<', '<')
-    opMap.set('≤', '<=')
-    opMap.set('=', '==')
-    opMap.set('≠', '!=')
-
-    return opMap
-  })
-
   const renderCalculatorButton = (
     index: number,
-    operator: string,
+    operator: string | IconType,
     mappedOperator: string
-  ) => (
-    <Box
-      key={index}
-      as="button"
-      h="40px"
-      w="40px"
-      borderRadius="3px"
-      _hover={{ bg: '#D6DEFF' }}
-      _active={{ bg: '#B7C0E6' }}
-      onClick={() => {
-        onClick(`${mappedOperator}`)
-      }}
-    >
-      <Text fontFamily="monospace" fontSize="16px">
-        {operator}
-      </Text>
-    </Box>
-  )
+  ) => {
+    const renderIcon = () => {
+      if (typeof operator === 'string') return operator
+
+      const OperatorIcon = operator
+      return <Icon as={OperatorIcon} />
+    }
+
+    return (
+      <Box
+        key={index}
+        as="button"
+        h="40px"
+        w="40px"
+        borderRadius="3px"
+        _hover={{ bg: '#D6DEFF' }}
+        _active={{ bg: '#B7C0E6' }}
+        onClick={() => {
+          onClick(`${mappedOperator}`)
+        }}
+      >
+        <Text fontFamily="monospace" fontSize="16px">
+          {renderIcon()}
+        </Text>
+      </Box>
+    )
+  }
 
   return (
     <Flex {...props}>
-      {Array.from(operatorMap).map((val, i) =>
-        renderCalculatorButton(i, val[0], val[1])
+      {OPERATOR_MAP.map(({ icon, value }, i) =>
+        renderCalculatorButton(i, icon, value)
+      )}
+      <Box py="4px">
+        <Divider orientation="vertical" borderColor="#DADCE3" />
+      </Box>
+      {FUNCTION_MAP.map(({ icon, value }, i) =>
+        renderCalculatorButton(i, icon, value)
       )}
     </Flex>
   )

--- a/src/client/components/displays/LineDisplay.tsx
+++ b/src/client/components/displays/LineDisplay.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { Stack, Text, useMultiStyleConfig } from '@chakra-ui/react'
-import xss from 'xss'
 
+import { sanitizeHtml } from '../../utils/sanitize-html'
 import '../../styles/inline-external-link.css'
 
 interface LineDisplayProps {
@@ -11,16 +11,6 @@ interface LineDisplayProps {
 
 export const LineDisplay: FC<LineDisplayProps> = ({ label, value }) => {
   const styles = useMultiStyleConfig('LineDisplay', { variant: 'base' })
-
-  const sanitizeHtml = (html: string) => {
-    const sanitizedHtml = xss(html, {
-      whiteList: { a: ['class', 'target', 'rel', 'href'] },
-      stripIgnoreTag: true,
-      stripIgnoreTagBody: ['script'],
-    })
-
-    return sanitizedHtml
-  }
 
   return (
     <Stack sx={styles.container} spacing="4px">

--- a/src/client/components/displays/LineDisplay.tsx
+++ b/src/client/components/displays/LineDisplay.tsx
@@ -3,6 +3,7 @@ import { Stack, Text, useMultiStyleConfig } from '@chakra-ui/react'
 
 import { sanitizeHtml } from '../../utils/sanitize-html'
 import '../../styles/inline-external-link.css'
+import '../../styles/line-display.css'
 
 interface LineDisplayProps {
   label: string
@@ -16,6 +17,7 @@ export const LineDisplay: FC<LineDisplayProps> = ({ label, value }) => {
     <Stack sx={styles.container} spacing="4px">
       <Text sx={styles.label}>{label}</Text>
       <Text
+        className="line-display"
         sx={styles.value}
         dangerouslySetInnerHTML={{
           __html: sanitizeHtml(value),

--- a/src/client/core/__test__/evaluator.spec.ts
+++ b/src/client/core/__test__/evaluator.spec.ts
@@ -208,6 +208,38 @@ describe('link', () => {
   })
 })
 
+describe('paragraph', () => {
+  it('should wrap content in <p> tag', () => {
+    const content = 'Hello world'
+    const expr = `paragraph("${content}")`
+
+    const output = evaluateOperation(expr, {})
+    expect(output).toBe(`<p>${content}</p>`)
+  })
+
+  it('should support links in the content', () => {
+    const displayText = 'Google'
+    const url = 'https://google.com'
+    const content = `link("${displayText}", "${url}")`
+    const expr = `paragraph(${content} + " here")`
+
+    const output = evaluateOperation(expr, {})
+    const link = `<a class="inline-external-link" target="_blank" rel="noopener noreferrer" href="${url}">${displayText}</a>`
+    expect(output).toBe(`<p>${link} here</p>`)
+  })
+
+  it('should sanitize content', () => {
+    const displayText = 'Google'
+    const url = 'https://google.com'
+    const content = `link("${displayText}", "${url}")`
+    const expr = `paragraph(${content} + "<script>var x = 1</script>")`
+
+    const output = evaluateOperation(expr, {})
+    const link = `<a class="inline-external-link" target="_blank" rel="noopener noreferrer" href="${url}">${displayText}</a>`
+    expect(output).toBe(`<p>${link}</p>`)
+  })
+})
+
 describe('variableReducer', () => {
   it('should apply evaluateOperation and accumulate variables', () => {
     const op: checker.Operation = {

--- a/src/client/core/evaluator.ts
+++ b/src/client/core/evaluator.ts
@@ -2,8 +2,10 @@
 import { typed, create, all, factory, Unit } from 'mathjs'
 import * as mathjs from 'mathjs'
 import { Graph, alg } from 'graphlib'
-import * as checker from '../../types/checker'
 import xss from 'xss'
+
+import * as checker from '../../types/checker'
+import { sanitizeHtml } from '../utils/sanitize-html'
 
 export class EvaluationCycleError extends Error {
   cycles: string[][]
@@ -85,6 +87,15 @@ const factories = {
 
     return a
   }),
+  // Custom paragraph function
+  paragraph: factory('paragraph', [], () =>
+    typed('paragraph', {
+      'string | number': (content: string | number) => {
+        const sanitized = sanitizeHtml(content.toString())
+        return `<p>${sanitized}</p>`
+      },
+    })
+  ),
 }
 export const math = create(factories, config)
 math.import!(

--- a/src/client/styles/line-display.css
+++ b/src/client/styles/line-display.css
@@ -1,0 +1,3 @@
+.line-display p {
+  margin-bottom: 8px;
+}

--- a/src/client/utils/sanitize-html.ts
+++ b/src/client/utils/sanitize-html.ts
@@ -1,0 +1,15 @@
+import xss from 'xss'
+
+const WHITELIST = {
+  a: ['class', 'target', 'rel', 'href'],
+  p: [],
+}
+export const sanitizeHtml = (html: string): string => {
+  const sanitized = xss(html, {
+    whiteList: WHITELIST,
+    stripIgnoreTag: true,
+    stripIgnoreTagBody: ['script'],
+  })
+
+  return sanitized
+}


### PR DESCRIPTION
## Problem

Closes #876 

## Solution

**Features**:
- Added `paragraph` function

**Improvements**:
- Added `link`, `paragraph` and quotes in calculator bar

## Screenshots

![image](https://user-images.githubusercontent.com/3666479/128309584-4d7da760-38c7-414e-8460-5ac656b0cfa1.png)

![image](https://user-images.githubusercontent.com/3666479/128309607-ebd8b1b2-cdf5-4d9f-be36-be132fcfd20d.png)

## Tests
- [ ] Create a result with `paragraph("Content A") + paragraph("Content B")`. It should be displayed on separate line in the result
- [ ] Create a result with `paragraph("Click " + link("here", "https://checkfirst.gov.sg"))`. It should display paragraph with link in the result
