### PR TITLE
feat(frontend): allow expansion for expression input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12188,6 +12188,16 @@
         "tslib": "^1.0.0"
       }
     },
+    "react-textarea-autosize": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
+      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.0.0",
+        "use-latest": "^1.0.0"
+      }
+    },
     "react-window": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
@@ -14395,6 +14405,11 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
+    },
     "ts-jest": {
       "version": "26.5.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
@@ -14758,6 +14773,27 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
+    },
+    "use-composed-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
+      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
+      "requires": {
+        "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+    },
+    "use-latest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
+      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0"
+      }
     },
     "use-sidecar": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "react-icons": "^4.2.0",
     "react-query": "^3.19.1",
     "react-router-dom": "^5.2.0",
+    "react-textarea-autosize": "^8.3.3",
     "react-window": "^1.8.6",
     "reflect-metadata": "^0.1.13",
     "scroll-behavior-polyfill": "^2.0.13",

--- a/src/client/components/builder/logic/ExpressionInput.tsx
+++ b/src/client/components/builder/logic/ExpressionInput.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react'
 import {
+  Box,
   Badge,
   HStack,
   Input,
@@ -17,6 +18,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { matchSorter, RankingInfo } from 'match-sorter'
+import TextareaAutoresize from 'react-textarea-autosize'
 
 import Downshift from 'downshift'
 
@@ -58,6 +60,7 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
 
   const inputRef = useRef<HTMLInputElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const cursorRef = useRef<HTMLSpanElement>(null)
 
   // hide calc bar and reset selection when clicking outside of the component
   useEffect(() => {
@@ -229,6 +232,26 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
 
   const currentMatches = getCurrentQueryMatches()
 
+  const CursorOverlay: FC<{ value: string }> = ({ value }) => {
+    const cursorPos = inputRef.current?.selectionStart
+    return (
+      <Box
+        visibility="hidden"
+        whiteSpace="pre-wrap"
+        w="100%"
+        h="100%"
+        py="8px"
+        px="16px"
+        sx={props.sx}
+        position="absolute"
+        top="0"
+      >
+        {cursorPos ? value.substring(0, cursorPos) : inputValue}
+        <span ref={cursorRef} />
+      </Box>
+    )
+  }
+
   return (
     <VStack align="stretch" position="relative" flex={1} w={0} ref={wrapperRef}>
       <Downshift
@@ -264,11 +287,14 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
             flex={1}
           >
             <Input
+              as={TextareaAutoresize}
               {...getInputProps({
                 placeholder:
                   placeholder || 'Type @ to reference a block in your formula',
                 ...props,
               })}
+              resize="none"
+              py="8px"
               value={inputValue || ''}
               ref={inputRef}
               onChange={(e) => setInputValue(e.currentTarget.value)}
@@ -279,17 +305,18 @@ export const ExpressionInput: FC<ExpressionInputProps> = ({
               }}
               onFocus={() => setHasFocus(true)}
             />
+            <CursorOverlay value={inputValue ?? ''} />
             <UnorderedList
               {...getMenuProps()}
               listStyleType="none"
               border={isOpen ? 'solid 1px #E2E8F0' : 0}
-              borderBottomRadius="6px"
               maxH="200px"
               overflowY="auto"
               position="absolute"
-              top="40px"
               bg="white"
-              w="100%"
+              w="300px"
+              top={`${(cursorRef.current?.offsetTop ?? 0) + 24}px`}
+              left={`${cursorRef.current?.offsetLeft ?? 0}px`}
               zIndex={99}
             >
               {isOpen


### PR DESCRIPTION
## Problem

Closes #877 

## Solution

**Features**:

- Use `TextareaAutoresize` to allow auto-resizing input field
- Use `CursorOverlay` to track the position of cursor and open autocomplete menu at cursor position

## Screenshots
![image](https://user-images.githubusercontent.com/3666479/128383131-c79e4a30-368f-418f-94eb-c14ede436f2e.png)

## Tests
- [ ] Enter a long expression. The `textarea` should automatically increase/increase in width
- [ ] Move cursor to different positions/lines. Autocomplete should open at the position of the cursor

## Deploy Notes

**New dependencies**:
- `react-textarea-autosize` : Auto expanding `textarea`

