### PR TITLE
fix(frontend): dropdown overlap and open close behaviour

### DIFF
--- a/src/client/components/common/Combobox.tsx
+++ b/src/client/components/common/Combobox.tsx
@@ -72,9 +72,13 @@ const ItemRenderer: FC<ItemRendererProps> = (props) => {
           item,
           index: props.index,
         })}
-        bg={highlightedIndex === props.index ? 'neutral.50' : 'none'}
+        bg={highlightedIndex === props.index ? 'neutral.200' : 'none'}
         py={'12px'}
         px={'20px'}
+        cursor="pointer"
+        _hover={{
+          bg: 'neutral.200',
+        }}
       >
         <HStack spacing={4}>
           <Text isTruncated>{item.label}</Text>
@@ -228,9 +232,9 @@ export const Combobox: FC<ComboboxProps> = ({
   // purely for adding padding insets to FixedStyleList
   // see https://codesandbox.io/s/react-window-list-padding-dg0pq
   const innerElementType = forwardRef(({ style, ...rest }, ref) => (
-    <div
+    <Box
       ref={ref}
-      style={{
+      sx={{
         ...style,
         height: `${parseFloat(style.height) + dropdownInset * 2}px`,
       }}
@@ -272,19 +276,13 @@ export const Combobox: FC<ComboboxProps> = ({
           position="relative"
           flex={1}
         >
-          <HStack
-            spacing={0}
-            zIndex={100}
-            backgroundColor="white"
-            borderRadius="5px"
-          >
+          <HStack spacing={0} backgroundColor="white" borderRadius="5px">
             <label {...getLabelProps()} hidden>
               {label}
             </label>
             <InputGroup>
               <Input
                 isDisabled={isDisabled}
-                zIndex={100}
                 borderRadius={
                   inputOptions?.useClearButton ? '5px 0px 0px 5px' : '5px'
                 }
@@ -333,48 +331,46 @@ export const Combobox: FC<ComboboxProps> = ({
                 borderRadius="0px 5px 5px 0px"
                 icon={<BiX size="16px" />}
                 onClick={() => {
-                  // reset field for new search
-                  setState({ inputValue: '' })
                   onChange('')
-                  updateSearchResults('')
-
-                  // refocus on input field
-                  input.focus()
+                  // Refocus after the blur event
+                  setTimeout(() => input.focus())
                 }}
               />
             ) : null}
           </HStack>
-          <Box
-            boxShadow="0px 0px 10px rgba(216, 222, 235, 0.5)"
-            position={'absolute'}
-            maxH={`${dropdownHeight}px`}
-            top={dropdownDir === DropdownDirection.down ? '40px' : undefined}
-            bottom={dropdownDir === DropdownDirection.up ? '40px' : undefined}
-            bg="white"
-            w="100%"
-            zIndex={99}
-          >
-            <FixedSizeList
-              {...getMenuProps({
-                ref: dropdownListRef,
-              })}
-              height={isOpen ? getDropdownHeight(searchResults.length) : 0}
-              itemSize={itemHeight}
-              itemCount={searchResults.length}
-              itemData={
-                {
-                  items: searchResults,
-                  highlightedIndex: highlightedIndex,
-                  getItemProps: getItemProps,
-                  selectedItem: selectedItem,
-                  topDropdownInset: dropdownInset,
-                } as ItemRendererProps['data']
-              }
-              innerElementType={innerElementType}
+          {isOpen && (
+            <Box
+              boxShadow="0px 0px 10px rgba(216, 222, 235, 0.5)"
+              position={'absolute'}
+              maxH={`${dropdownHeight}px`}
+              top={dropdownDir === DropdownDirection.down ? '40px' : undefined}
+              bottom={dropdownDir === DropdownDirection.up ? '40px' : undefined}
+              bg="white"
+              w="100%"
+              zIndex={99}
             >
-              {ItemRenderer}
-            </FixedSizeList>
-          </Box>
+              <FixedSizeList
+                {...getMenuProps({
+                  ref: dropdownListRef,
+                })}
+                height={getDropdownHeight(searchResults.length)}
+                itemSize={itemHeight}
+                itemCount={searchResults.length}
+                itemData={
+                  {
+                    items: searchResults,
+                    highlightedIndex: highlightedIndex,
+                    getItemProps: getItemProps,
+                    selectedItem: selectedItem,
+                    topDropdownInset: dropdownInset,
+                  } as ItemRendererProps['data']
+                }
+                innerElementType={innerElementType}
+              >
+                {ItemRenderer}
+              </FixedSizeList>
+            </Box>
+          )}
         </VStack>
       )}
     </Downshift>

--- a/src/client/components/common/Combobox.tsx
+++ b/src/client/components/common/Combobox.tsx
@@ -10,6 +10,7 @@ import {
   IconButton,
   Box,
   forwardRef,
+  Icon,
 } from '@chakra-ui/react'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
 import Downshift, {
@@ -19,7 +20,7 @@ import Downshift, {
 } from 'downshift'
 import { matchSorter, MatchSorterOptions } from 'match-sorter'
 import React, { FC, RefCallback, useMemo, useRef, useState } from 'react'
-import { BiChevronDown, BiX } from 'react-icons/bi'
+import { BiChevronDown, BiChevronUp, BiX } from 'react-icons/bi'
 import { FieldOption } from '../../../types/checker'
 
 enum DropdownDirection {
@@ -262,7 +263,7 @@ export const Combobox: FC<ComboboxProps> = ({
         highlightedIndex,
         isOpen,
         openMenu,
-        setState,
+        closeMenu,
       }) => (
         <VStack
           {...getRootProps()}
@@ -304,10 +305,22 @@ export const Combobox: FC<ComboboxProps> = ({
                   },
                 })}
               />
-              <InputRightElement pointerEvents="none">
-                <BiChevronDown
+              <InputRightElement>
+                <Icon
+                  as={
+                    isOpen && searchResults.length > 0
+                      ? BiChevronUp
+                      : BiChevronDown
+                  }
                   aria-label="dropdown-icon"
                   color={isDisabled ? '#A5ABB3' : 'black'}
+                  cursor="pointer"
+                  onClick={() => {
+                    if (isOpen) return closeMenu()
+
+                    setDropdownDir(calculateDropdownDirection())
+                    openMenu(() => dropdownListRef.current?.scrollTo(0))
+                  }}
                 />
               </InputRightElement>
             </InputGroup>


### PR DESCRIPTION
## Problem

- Dropdown options was hidden behind a previous dropdown input
- Open/close chevron were working properly

## Solution

**Improvements**:
- Fix z-index of dropdown options
- Add behaviour to open/close chevron

## Screenshots
![image](https://user-images.githubusercontent.com/3666479/129672488-6b491fa9-265a-4fa5-8155-3a6b7c4d481f.png)

## Tests
- [ ] Create two dropdown question consecutively and reduce the size of the screen such that the dropdown menu opens upwards. The second dropdown options should not be hidden behind the first input.
- [ ] Clicking the open and close chevron should toggle the dropdown menu