### PR TITLE
fix(masthead): shorten "how to identify" line

### DIFF
--- a/src/client/components/Masthead.tsx
+++ b/src/client/components/Masthead.tsx
@@ -55,7 +55,7 @@ export const Masthead: FC<MastheadProps> = ({ width }) => {
                 textDecor="underline"
                 onClick={onToggle}
               >
-                How to identify it? <Icon boxSize="16px" as={BiChevronDown} />
+                How to identify <Icon boxSize="16px" as={BiChevronDown} />
               </Link>
             </Text>
           </Flex>


### PR DESCRIPTION
## Problem and Solution
The "how to identify" line as proposed by our designers used language 
as defined by this change. Remove the extraneous " it?" bit to align with
other places where this is found, eg, sites built on Isomer
