### PR TITLE
fix: indexing for new radio or checkbox option

### DIFF
--- a/src/client/components/builder/questions/CheckboxField.tsx
+++ b/src/client/components/builder/questions/CheckboxField.tsx
@@ -64,9 +64,9 @@ const InputComponent: QuestionFieldComponent = ({ field, index, toolbar }) => {
   }
 
   const addOption = () => {
-    const newOptionLabel = `Option ${field.options.length + 1}`
+    const newOptionLabel = `Option ${options.length + 1}`
     // newValue is an increment of the last option's value to ensure that values are unique
-    const newValue = field.options[field.options.length - 1].value + 1
+    const newValue = options[options.length - 1].value + 1
     const newOption = { label: newOptionLabel, value: newValue }
     append(newOption)
   }

--- a/src/client/components/builder/questions/RadioField.tsx
+++ b/src/client/components/builder/questions/RadioField.tsx
@@ -63,9 +63,9 @@ const InputComponent: QuestionFieldComponent = ({ field, index, toolbar }) => {
   }
 
   const addOption = () => {
-    const newOptionLabel = `Option ${field.options.length + 1}`
+    const newOptionLabel = `Option ${options.length + 1}`
     // newValue is an increment of the last option's value to ensure that values are unique
-    const newValue = field.options[field.options.length - 1].value + 1
+    const newValue = options[options.length - 1].value + 1
     const newOption = { label: newOptionLabel, value: newValue }
     append(newOption)
   }
@@ -92,7 +92,7 @@ const InputComponent: QuestionFieldComponent = ({ field, index, toolbar }) => {
           aria-label="Delete option"
           icon={<BiTrash />}
           variant="link"
-          disabled={field.options.length <= 1}
+          disabled={options.length <= 1}
           onClick={() => deleteOption(i)}
         />
       </HStack>


### PR DESCRIPTION
## Problem

New options index was not referring to the react hook form field array. `addOption` should be referring to `options` instead of `field.options`, which is only updated after each save. Therefore, radio and checkbox options that have more than three options would not work as the index will always be `1` for all new option since `field.options` is still the same length.

To reproduce on production:
1. Create a new check with 3 radio option
2. Create a result that has returns the value of the radio question
3. Select the third option 
4. Notice that when the third option is selected, the second option is also selected.

This only affect checkers that tried to add an option after the block validation feature as introduced. 

## Solution

**Bug Fixes**:
- Reference `options` from react hook form for radio and checkbox questions.

## Tests
- [ ] Create a new checker with 3 radio options. Check that the values/index are correct for each of them. Use a calculated result to print the selected option to verify
- [ ] Create a new checker with 3 checkbox options. Check that the values/index are correct for each of them. Use a calculated result to print the selected option to verify