### PR TITLE
fix: replace deprecated disableHostCheck config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = () => {
         '/api': 'http://localhost:8080',
       },
       historyApiFallback: true,
-      disableHostCheck: true,
+      allowedHosts: 'auto',
     },
     devtool: 'source-map',
     plugins: [


### PR DESCRIPTION
## Problem

`disableHostCheck` had been deprecated. It is now replaced with `allowedHosts`.

## Solution

**Bug Fixes**:
- Set `allowedHosts` to `auto`

## Tests
- [ ] Ensure that `npm run dev` works