### PR TITLE
feat: remove extra whoami call for public checker page

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -31,6 +31,13 @@ provider:
       Resource:
         '*'
 
+package:
+  exclude:
+    - node_modules/@chakra-ui/**
+    - node_modules/@emotion/**
+    - node_modules/@loadable/**
+    - node_modules/react*/**
+
 functions:
   api:
     description: commit-${env:GITHUB_SHA}/run-${env:GITHUB_RUN_ID}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -45,27 +45,32 @@ const App: FC = () => {
       <QueryClientProvider client={queryClient}>
         <Router history={history}>
           <GoogleAnalyticsProvider>
-            <AuthProvider>
-              <Sentry.ErrorBoundary
-                fallback={({ resetError }) => (
-                  <Fallback resetError={resetError} />
-                )}
-              >
-                <Switch>
-                  <Route exact path="/c/:id" component={Checker} />
-                  <Route exact path="/login" component={Login} />
-                  <Route exact path="/" component={Landing} />
-                  <PrivateRoute path="/dashboard" component={Dashboard} />
-                  <PrivateRoute path="/builder/:id">
-                    {/* TODO: Rename to BuilderProvider */}
-                    <CheckerProvider>
-                      <FormBuilder />
-                    </CheckerProvider>
-                  </PrivateRoute>
-                  <Redirect to="/" />
-                </Switch>
-              </Sentry.ErrorBoundary>
-            </AuthProvider>
+            <Sentry.ErrorBoundary
+              fallback={({ resetError }) => (
+                <Fallback resetError={resetError} />
+              )}
+            >
+              <Switch>
+                <Route exact path="/c/:id" component={Checker} />
+                {/* Only apply AuthProvider to all other routes to avoid extraneous API call */}
+                <Route>
+                  <AuthProvider>
+                    <Switch>
+                      <Route exact path="/login" component={Login} />
+                      <Route exact path="/" component={Landing} />
+                      <PrivateRoute path="/dashboard" component={Dashboard} />
+                      <PrivateRoute path="/builder/:id">
+                        {/* TODO: Rename to BuilderProvider */}
+                        <CheckerProvider>
+                          <FormBuilder />
+                        </CheckerProvider>
+                      </PrivateRoute>
+                      <Redirect to="/" />
+                    </Switch>
+                  </AuthProvider>
+                </Route>
+              </Switch>
+            </Sentry.ErrorBoundary>
           </GoogleAnalyticsProvider>
         </Router>
       </QueryClientProvider>


### PR DESCRIPTION
## Problem

Public checker page should not require a call to `/whoami`.

## Solution

**Features**:
- Remove `/whoami` call on public checker page

**Others**
- Manually excluded frontend dependencies in `serverless.yml`. This is not ideal and should be tackled through addressing issues #1103 

## Tests
- [ ] Verify that public checker page still works as expected and `/whoami` is not called
- [ ] Verify that logged in user should still get redirected to `/dashboard` when navigating to landing page
- [ ] Non-existent URLs should still get redirected to the landing page
- [ ] Navigation through the dashboard still still work as expected