### PR TITLE
chore: disable `webpack-dev-server` warnings overlay

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,7 +101,9 @@ module.exports = () => {
         'process.env.FRONTEND_SENTRY_DSN': JSON.stringify(
           process.env.FRONTEND_SENTRY_DSN
         ),
-        'process.env.NODE_ENV': JSON.stringify(process.env.LAMBDA_NODE_ENV),
+        'process.env.NODE_ENV': JSON.stringify(
+          process.env.LAMBDA_NODE_ENV || 'development'
+        ),
       }),
     ],
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,9 @@ module.exports = () => {
       },
       historyApiFallback: true,
       allowedHosts: 'auto',
+      client: {
+        overlay: { errors: true, warnings: false },
+      },
     },
     devtool: 'source-map',
     plugins: [


### PR DESCRIPTION
## Problem

Upgraded `webpack-dev-server` presents an overlay for warnings by default. This hinders development if the warnings are known and can be ignored.

## Solution

**Improvements**:

- Update configuration to disable overlay for `webpack-dev-server`

**Bug Fixes**:

- Provided a default value for `LAMBDA_NODE_ENV` during development