### PR TITLE
feat: improve validation for OtpForm and LoginForm

### DIFF
--- a/src/client/components/LoginForm.tsx
+++ b/src/client/components/LoginForm.tsx
@@ -71,35 +71,38 @@ export const LoginForm: FC<LoginFormProps> = ({ email, onLogin }) => {
     )
   }
 
-  const hasError = () => errors.email || auth.verifyOtp.isError
+  const hasError = (): boolean => !!errors.token || auth.verifyOtp.isError
 
   const getErrorMessage = (): string => {
-    const { otp } = errors
-    return otp && otp.type === 'required'
+    return errors && errors.token
       ? 'Please provide a valid OTP'
-      : getApiErrorMessage(auth.verifyOtp.error)
+      : auth.verifyOtp.isError
+      ? getApiErrorMessage(auth.verifyOtp.error)
+      : ''
   }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <VStack spacing="32px" align="stretch">
-        <FormControl id="email" isInvalid={hasError()}>
-          <FormLabel color="neutral.900">One time password</FormLabel>
+        <FormControl id="token" isInvalid={hasError()}>
+          <FormLabel color="neutral.900" isRequired>
+            One time password
+          </FormLabel>
           <Text color="neutral.700" mb="24px">
             Please enter the OTP sent to {email}.
           </Text>
           <Input
             h="48px"
-            type="text"
-            inputMode="numeric"
-            pattern="\d{6}"
-            {...register('token', { required: true })}
+            {...register('token', {
+              required: true,
+              minLength: 6,
+              maxLength: 6,
+              pattern: /^\d{6}/,
+            })}
             autoComplete="one-time-code"
             placeholder="e.g. 111111"
           />
-          {hasError() && (
-            <FormErrorMessage>{getErrorMessage()}</FormErrorMessage>
-          )}
+          <FormErrorMessage children={getErrorMessage()} />
         </FormControl>
         <HStack justifyContent="flex-start" spacing={6}>
           <Button

--- a/src/client/components/OtpForm.tsx
+++ b/src/client/components/OtpForm.tsx
@@ -39,12 +39,11 @@ export const OtpForm: FC<OtpFormProps> = ({ onSuccess }) => {
     sendOtp.mutate(formattedEmail)
   }
 
-  const hasError = () => errors.email || sendOtp.isError
+  const hasError = (): boolean => !!errors.email || sendOtp.isError
 
   const getErrorMessage = (): string => {
-    const { email } = errors
-    return email && email.type === 'required'
-      ? 'Please provide a valid email address'
+    return errors && errors.email
+      ? 'Please provide a valid .gov.sg email address'
       : getApiErrorMessage(sendOtp.error)
   }
 
@@ -55,12 +54,15 @@ export const OtpForm: FC<OtpFormProps> = ({ onSuccess }) => {
           <FormLabel label="neutral.900">Login</FormLabel>
           <Text color="neutral.700" mb="24px">
             Only available for use by public officers with a{' '}
-            <strong>gov.sg</strong> email.
+            <strong>.gov.sg</strong> email.
           </Text>
           <Input
             h="48px"
-            type="email"
-            {...register('email', { required: true })}
+            {...register('email', {
+              required: true,
+              pattern:
+                /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+.gov.sg$/,
+            })}
             placeholder="e.g. jane@open.gov.sg"
           />
           {hasError() && (


### PR DESCRIPTION
While working on https://github.com/opengovsg/CheckWho/pull/251, thought to transpose the code changes to checkfirst.

Advantages:
- More stringent frontend validation for email; must be *@*.gov.sg email, and not just any email
- Error case looks more aesthetic using react-hook-form and Chakra UI's FormControl, compared to default HTML

BEFORE:
![SCR-20220414-uqh](https://user-images.githubusercontent.com/67887489/163408108-49eaaeca-6b17-4d56-b1f9-9c5b1190ebb2.png)
![image](https://user-images.githubusercontent.com/67887489/163408178-f5dcba18-a705-440d-a58f-f7b2a91a1a85.png)

AFTER:
![SCR-20220414-st9](https://user-images.githubusercontent.com/67887489/163408237-9d0d75c1-469b-4f8c-a4cf-1cd5cc06709e.png)

