### PR TITLE
fix: properly disable bad options in add logic #1275

### DIFF
--- a/src/client/components/builder/LogicTab.tsx
+++ b/src/client/components/builder/LogicTab.tsx
@@ -280,8 +280,8 @@ export const LogicTab: FC = () => {
                     Add logic
                   </MenuButton>
                   <MenuList>
-                    {addMenu.map(({ label, icon, onClick }, i) => (
-                      <MenuItem onClick={onClick} key={i}>
+                    {addMenu.map(({ label, icon, onClick, disabled }, i) => (
+                      <MenuItem onClick={onClick} key={i} isDisabled={disabled}>
                         <MenuIcon mr={4}>{icon}</MenuIcon>
                         {label}
                       </MenuItem>


### PR DESCRIPTION
## Problem

Closes #1275

## Solution

Used the `disabled` values in rendering the Menu.

## Before & After Screenshots

**BEFORE**:
<img width="283" alt="Screenshot 2022-04-21 at 6 41 00 AM" src="https://user-images.githubusercontent.com/932949/164337816-aeb181bd-bf6c-41db-b4a1-fe1640712f74.png">

**AFTER**:
<img width="271" alt="Screenshot 2022-04-21 at 6 53 52 AM" src="https://user-images.githubusercontent.com/932949/164337870-c38d1336-33bc-4a24-b884-463589c713d5.png">

## Tests

* Scenario: No Date Field
  * The Date Calculation Menu option should remain **disabled**.

* Scenario: No Constant Map
  * The Map Constant Menu option should remain **disabled**.
  
* Scenario: At least one Constant Map
  * The Map Constant Menu option should remain **enabled**.
  
* Scenario: At least one Date Field
  * The Date Calculation menu option should remain **enabled**.