### PR TITLE
fix: delete the correct condition instead of the last one #1266

### DIFF
--- a/src/client/components/builder/logic/ConditionalResult.tsx
+++ b/src/client/components/builder/logic/ConditionalResult.tsx
@@ -205,7 +205,7 @@ const InputComponent: OperationFieldComponent = ({
         <Box sx={styles.deleteSpacer} />
       </HStack>
       {conditions.map((cond, i) => (
-        <HStack key={i} sx={styles.inputContainer}>
+        <HStack key={cond.id} sx={styles.inputContainer}>
           {i === 0 ? (
             <Menu autoSelect={false}>
               <MenuButton


### PR DESCRIPTION
## Problem

Closes #1266

## Solution

I just used the passed the ID of a Condition as the key, instead of the index.

**Bug Fixes**:

- Deletes the correct entry from Conditions, when the corresponding trash icon is clicked.

## Before & After Screenshots

**BEFORE**:
![before](https://user-images.githubusercontent.com/932949/164384674-ca2f4039-09fa-4ac2-ba76-fd82bf72dc0e.gif)

**AFTER**:
![after](https://user-images.githubusercontent.com/932949/164384736-07a0dc0c-d3b0-4546-b525-b384d47dd294.gif)

## Tests

_What tests should be run to confirm functionality?_

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
