### PR TITLE
fix: store constant values as Number

### DIFF
--- a/src/client/components/builder/constants/MapTable.tsx
+++ b/src/client/components/builder/constants/MapTable.tsx
@@ -163,6 +163,7 @@ const InputComponent: ConstantFieldComponent = ({
                     type="number"
                     placeholder="Numeric Value"
                     {...register(`table.${index}.value`, {
+                      valueAsNumber: true,
                       required: {
                         value: true,
                         message: 'Table row value cannot be empty',


### PR DESCRIPTION
## Problem

CheckFirst is saving constant values as string instead of Number, and that's hurting functionality, since constants are meant to be numbers. This will affect logic applied to the values

## Solution

**Bug Fixes**:

Ensure that the MapTable component returns a number for the mapped value on the frontend