### PR TITLE
chore(lambda): upgrade runtime to node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,10 @@ jobs:
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   stage: ${env:LAMBDA_NODE_ENV}
   region: ap-southeast-1
   memorySize: 256


### PR DESCRIPTION
## Problem and Solution

Update runtime to node 16, the latest supported by AWS lambda