### PR TITLE
fix(if): support Unit types

### DIFF
--- a/src/shared/core/__test__/evaluator.spec.ts
+++ b/src/shared/core/__test__/evaluator.spec.ts
@@ -81,6 +81,14 @@ describe('Operation', () => {
       expect(output).toBe(10)
     })
 
+    it('should support [unit, unit] outputs', () => {
+      const expected = unit(`${Date.now() / 1000} seconds`)
+      const c = unit(`${Date.now() / 1000} seconds`)
+      const expr = 'ifelse(a > b, expected, expected)'
+      const output = evaluateOperation(expr, { a: 2, b: 1, c, expected })
+      expect(output).toBe(expected)
+    })
+
     it('should support [string, number] outputs', () => {
       const expr = 'ifelse(a > b, "hello", 20)'
       const output = evaluateOperation(expr, { a: 2, b: 1 })
@@ -91,6 +99,50 @@ describe('Operation', () => {
       const expr = 'ifelse(a > b, 10, "hello")'
       const output = evaluateOperation(expr, { a: 2, b: 1 })
       expect(output).toBe(10)
+    })
+
+    it('should support [number, unit] outputs', () => {
+      const expected = unit(`${Date.now() / 1000} seconds`)
+      const expr = 'ifelse(a > b, expected, 0)'
+      const output = evaluateOperation(expr, {
+        a: 2,
+        b: 1,
+        expected,
+      })
+      expect(output).toBe(expected)
+    })
+
+    it('should support [unit, number] outputs', () => {
+      const expected = unit(`${Date.now() / 1000} seconds`)
+      const expr = 'ifelse(a > b, 0, expected)'
+      const output = evaluateOperation(expr, {
+        a: 1,
+        b: 2,
+        expected,
+      })
+      expect(output).toBe(expected)
+    })
+
+    it('should support [string, unit] outputs', () => {
+      const expected = unit(`${Date.now() / 1000} seconds`)
+      const expr = 'ifelse(a > b, expected, "unexpected")'
+      const output = evaluateOperation(expr, {
+        a: 2,
+        b: 1,
+        expected,
+      })
+      expect(output).toBe(expected)
+    })
+
+    it('should support [unit, string] outputs', () => {
+      const expected = unit(`${Date.now() / 1000} seconds`)
+      const expr = 'ifelse(a > b, "unexpected", expected)'
+      const output = evaluateOperation(expr, {
+        a: 1,
+        b: 2,
+        expected,
+      })
+      expect(output).toBe(expected)
     })
 
     it('should not accept a string conditional', () => {
@@ -142,6 +194,17 @@ describe('countif', () => {
   it('should support [number[], number] inputs', () => {
     const expr = 'countif([a, b], 7)'
     const output = evaluateOperation(expr, { a: 7, b: 8 })
+    expect(output).toBe(1)
+  })
+
+  it('should support [unit[], unit] inputs', () => {
+    const refDate: Unit = unit(`${Date.now() / 1000} seconds`)
+    const expr = 'countif([a, b], c)'
+    const output = evaluateOperation(expr, {
+      a: refDate,
+      b: unit(`${Date.now() / 1000} seconds`),
+      c: refDate,
+    })
     expect(output).toBe(1)
   })
 

--- a/src/shared/core/evaluator.ts
+++ b/src/shared/core/evaluator.ts
@@ -48,22 +48,22 @@ const factories = {
   // Custom if-else function
   createIfElse: factory('ifelse', [], () =>
     typed('ifelse', {
-      'boolean, string | number, string | number': (
+      'boolean, string | number | Unit, string | number | Unit': (
         condition: boolean,
-        a: string | number,
-        b: string | number
+        a: string | number | Unit,
+        b: string | number | Unit
       ) => (condition ? a : b),
     })
   ),
   // Custom count-if function
   createCountIf: factory('countif', [], () =>
     typed('countif', {
-      'Array, string | number': (
-        elemArray: string[] | number[],
-        comparedElem: string | number
+      'Array, string | number | Unit': (
+        elemArray: string[] | number[] | Unit[],
+        comparedElem: string | number | Unit
       ) => {
         let count = 0
-        elemArray.forEach((elem: string | number) => {
+        elemArray.forEach((elem: string | number | Unit) => {
           if (elem === comparedElem) count++
         })
         return count


### PR DESCRIPTION
## Problem

Dates cannot be used as arguments for `ifelse` and `countif` functions

## Solution

Allow for Unit data types in `evaluator` expressions for those functions